### PR TITLE
Part 2 · Issue C — LangGraph RAG pipeline (retrieve → generate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test:integration": "vitest run tests/integration"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.89.0",
+    "@langchain/core": "^1.1.39",
+    "@langchain/langgraph": "^1.2.8",
     "@pinecone-database/pinecone": "^7.2.0",
     "gray-matter": "^4.0.3",
     "next": "16.2.3",

--- a/pipeline/graph.ts
+++ b/pipeline/graph.ts
@@ -1,6 +1,18 @@
-// TODO(M2): wire the compiled StateGraph (retrieve → generate) here.
-// Intentional stub — types consumed from shared/types.ts.
+import { StateGraph } from "@langchain/langgraph";
+import { Pinecone } from "@pinecone-database/pinecone";
+import Anthropic from "@anthropic-ai/sdk";
+import { GraphStateAnnotation } from "./state";
+import { createRetrieveNode } from "./nodes/retrieve";
+import { createGenerateNode } from "./nodes/generate";
 
-import type { GraphState } from "@/shared/types";
+const vectorStore = new Pinecone({ apiKey: process.env.PINECONE_API_KEY! })
+  .index(process.env.PINECONE_INDEX!);
+const anthropic = new Anthropic();
 
-export type { GraphState };
+export const graph = new StateGraph(GraphStateAnnotation)
+  .addNode("retrieve", createRetrieveNode(vectorStore))
+  .addNode("generate", createGenerateNode(anthropic))
+  .addEdge("__start__", "retrieve")
+  .addEdge("retrieve", "generate")
+  .addEdge("generate", "__end__")
+  .compile();

--- a/pipeline/nodes/generate.ts
+++ b/pipeline/nodes/generate.ts
@@ -1,0 +1,61 @@
+import Anthropic from "@anthropic-ai/sdk";
+import type { GraphState } from "../state";
+import type { Citation } from "../../shared/types";
+
+const SYSTEM_PROMPT = `You are a compliance assistant. Answer questions using ONLY the provided source chunks below.
+Use inline citation markers like [^1], [^2], etc. to reference specific chunks when making claims.
+If the provided chunks are empty or do not contain sufficient information to answer the question,
+respond with exactly: "I cannot answer from the available sources."
+Never fabricate information or cite sources not provided to you.`;
+
+function formatContext(state: GraphState): string {
+  if (state.retrievals.length === 0) {
+    return "(No source chunks available.)";
+  }
+  return state.retrievals
+    .map((r, i) => `[^${i + 1}] ${r.text}`)
+    .join("\n\n");
+}
+
+function parseCitations(answer: string, state: GraphState): Citation[] {
+  const markers = new Set<number>();
+  const regex = /\[\^(\d+)\]/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(answer)) !== null) {
+    const n = parseInt(match[1], 10);
+    if (n >= 1 && n <= state.retrievals.length) {
+      markers.add(n);
+    }
+  }
+
+  return Array.from(markers)
+    .sort((a, b) => a - b)
+    .map((n) => ({
+      chunkId: state.retrievals[n - 1].chunkId,
+      marker: `[^${n}]`,
+    }));
+}
+
+export function createGenerateNode(anthropic: Anthropic) {
+  return async (state: GraphState): Promise<Partial<GraphState>> => {
+    const context = formatContext(state);
+    const userContent = `Source chunks:\n\n${context}\n\nQuestion: ${state.query}`;
+
+    const response = await anthropic.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: "user", content: userContent }],
+    });
+
+    const textBlock = response.content.find((b) => b.type === "text");
+    const answer = textBlock && textBlock.type === "text" ? textBlock.text : "";
+
+    const citations = parseCitations(answer, state);
+
+    return {
+      answer,
+      citations: citations.length > 0 ? citations : undefined,
+    };
+  };
+}

--- a/pipeline/nodes/retrieve.ts
+++ b/pipeline/nodes/retrieve.ts
@@ -1,0 +1,22 @@
+import { Pinecone } from "@pinecone-database/pinecone";
+import type { GraphState } from "../state";
+import type { Retrieval } from "../../shared/types";
+
+export function createRetrieveNode(
+  vectorStore: ReturnType<Pinecone["index"]>
+) {
+  return async (state: GraphState): Promise<Partial<GraphState>> => {
+    const response = await vectorStore.searchRecords({
+      query: { topK: 5, inputs: { text: state.query } },
+    });
+
+    const retrievals: Retrieval[] = response.result.hits.map((hit) => ({
+      chunkId: hit._id,
+      text: (hit.fields as Record<string, unknown>)["text"] as string,
+      score: hit._score,
+      metadata: undefined,
+    }));
+
+    return { retrievals };
+  };
+}

--- a/pipeline/state.ts
+++ b/pipeline/state.ts
@@ -1,6 +1,14 @@
-// TODO(M2): define the LangGraph StateGraph annotation and reducers here.
-// Intentional stub — types consumed from shared/types.ts.
+import { Annotation } from "@langchain/langgraph";
+import type { Retrieval, Citation } from "../shared/types";
 
-import type { GraphState } from "@/shared/types";
+export const GraphStateAnnotation = Annotation.Root({
+  query: Annotation<string>,
+  retrievals: Annotation<Retrieval[]>({
+    reducer: (a, b) => [...a, ...b],
+    default: () => [],
+  }),
+  answer: Annotation<string | undefined>,
+  citations: Annotation<Citation[] | undefined>,
+});
 
-export type { GraphState };
+export type GraphState = typeof GraphStateAnnotation.State;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.89.0
+        version: 0.89.0(zod@4.3.6)
+      '@langchain/core':
+        specifier: ^1.1.39
+        version: 1.1.39
+      '@langchain/langgraph':
+        specifier: ^1.2.8
+        version: 1.2.8(@langchain/core@1.1.39)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
       '@pinecone-database/pinecone':
         specifier: ^7.2.0
         version: 7.2.0
@@ -70,6 +79,15 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@anthropic-ai/sdk@0.89.0':
+    resolution: {integrity: sha512-nyGau0zex62EpU91hsHa0zod973YEoiMgzWZ9hC55WdiOLrE4AGpcg4wXI7lFqtvMLqMcLfewQU9sHgQB6psow==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -125,6 +143,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -136,6 +158,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -524,6 +549,47 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@langchain/core@1.1.39':
+    resolution: {integrity: sha512-DP9c7TREy6iA7HnywstmUAsNyJNYTFpRg2yBfQ+6H0l1HnvQzei9GsQ36GeOLxgRaD3vm9K8urCcawSC7yQpCw==}
+    engines: {node: '>=20'}
+
+  '@langchain/langgraph-checkpoint@1.0.1':
+    resolution: {integrity: sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.0.1
+
+  '@langchain/langgraph-sdk@1.8.8':
+    resolution: {integrity: sha512-4OoqFAvPloOTZ6oPxXbJngz4FLJO8QSXb+BQV3qvNTvmfu1LQA7cCEqSNLYX9MoC340PbnDkHNgUtjajwkDHRg==}
+    peerDependencies:
+      '@langchain/core': ^1.1.16
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+      svelte: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
+  '@langchain/langgraph@1.2.8':
+    resolution: {integrity: sha512-kKkRpC5xFz1e6vPivE7lwRJa5oahLAMaVQvVGZdTa6uJIchIYJDIuM1n93FqGvg8aYVcgYU4FENtKKC5Eh1JYw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.1.16
+      zod: ^3.25.32 || ^4.2.0
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -959,6 +1025,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -1048,6 +1118,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.19:
     resolution: {integrity: sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==}
     engines: {node: '>=6.0.0'}
@@ -1092,6 +1165,10 @@ packages:
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
@@ -1171,6 +1248,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1388,6 +1469,12 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1638,6 +1725,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.3.1:
+    resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
+    engines: {node: '>=16'}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -1696,6 +1787,9 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  js-tiktoken@1.0.21:
+    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1714,6 +1808,10 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1740,6 +1838,26 @@ packages:
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+
+  langsmith@0.5.19:
+    resolution: {integrity: sha512-5tFoETuFMvGkbPGsINNlIE4Ab86CsPhdPOQZCGwNt/NX0h5NDKQLKOWS/G2XcRUBOQl4mCNbrayUvUTWaIRsCg==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+      ws: '>=7'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
+      ws:
+        optional: true
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -1875,6 +1993,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -1970,6 +2092,10 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -1977,6 +2103,26 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-queue@9.1.2:
+    resolution: {integrity: sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==}
+    engines: {node: '>=20'}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -2328,6 +2474,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -2401,6 +2550,18 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -2536,6 +2697,12 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@anthropic-ai/sdk@0.89.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -2613,6 +2780,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -2635,6 +2804,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@cfworker/json-schema@4.1.1': {}
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -2902,6 +3073,56 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@langchain/core@1.1.39':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.5.19
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      uuid: 11.1.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.39)':
+    dependencies:
+      '@langchain/core': 1.1.39
+      uuid: 10.0.0
+
+  '@langchain/langgraph-sdk@1.8.8(@langchain/core@1.1.39)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 9.1.2
+      p-retry: 7.1.1
+      uuid: 13.0.0
+    optionalDependencies:
+      '@langchain/core': 1.1.39
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@langchain/langgraph@1.2.8(@langchain/core@1.1.39)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)':
+    dependencies:
+      '@langchain/core': 1.1.39
+      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.39)
+      '@langchain/langgraph-sdk': 1.8.8(@langchain/core@1.1.39)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - svelte
+      - vue
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -3262,6 +3483,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -3373,6 +3596,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.19: {}
 
   binary-extensions@2.3.0: {}
@@ -3418,6 +3643,8 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase-css@2.0.1: {}
+
+  camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001788: {}
 
@@ -3491,6 +3718,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decamelize@1.2.0: {}
 
   deep-is@0.1.4: {}
 
@@ -3877,6 +4106,10 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
+
   expect-type@1.3.0: {}
 
   extend-shallow@2.0.1:
@@ -4130,6 +4363,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-network-error@1.3.1: {}
+
   is-number-object@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -4191,6 +4426,10 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  js-tiktoken@1.0.21:
+    dependencies:
+      base64-js: 1.5.1
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -4205,6 +4444,11 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -4228,6 +4472,11 @@ snapshots:
       json-buffer: 3.0.1
 
   kind-of@6.0.3: {}
+
+  langsmith@0.5.19:
+    dependencies:
+      p-queue: 6.6.2
+      uuid: 10.0.0
 
   language-subtag-registry@0.3.23: {}
 
@@ -4331,6 +4580,8 @@ snapshots:
   minimist@1.2.8: {}
 
   ms@2.1.3: {}
+
+  mustache@4.2.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -4440,6 +4691,8 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-finally@1.0.0: {}
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -4447,6 +4700,26 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-queue@9.1.2:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
+  p-timeout@7.0.1: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -4879,6 +5152,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  ts-algebra@2.0.0: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -4995,6 +5270,12 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
+
+  uuid@11.1.0: {}
+
+  uuid@13.0.0: {}
 
   vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0):
     dependencies:

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -31,9 +31,5 @@ export interface Chunk {
   readonly metadata: ChunkMetadata;
 }
 
-export interface GraphState {
-  readonly query: string;
-  readonly retrievals: readonly Retrieval[];
-  readonly answer?: string;
-  readonly citations?: readonly Citation[];
-}
+// GraphState is derived from the LangGraph annotation in pipeline/state.ts.
+export type { GraphState } from "../pipeline/state";

--- a/tests/unit/pipeline.test.ts
+++ b/tests/unit/pipeline.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from "vitest";
+import { createRetrieveNode } from "../../pipeline/nodes/retrieve";
+import { createGenerateNode } from "../../pipeline/nodes/generate";
+import type { GraphState } from "../../pipeline/state";
+
+// ---------------------------------------------------------------------------
+// Shared fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeState(overrides: Partial<GraphState> = {}): GraphState {
+  return {
+    query: "What are the disclosure requirements?",
+    retrievals: [],
+    answer: undefined,
+    citations: undefined,
+    ...overrides,
+  };
+}
+
+function makeVectorStoreMock(hits: object[]) {
+  return {
+    searchRecords: vi.fn().mockResolvedValue({
+      result: { hits },
+      usage: { readUnits: 1 },
+    }),
+  };
+}
+
+function makeAnthropicMock(answerText: string) {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: answerText }],
+        model: "claude-haiku-4-5-20251001",
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 20 },
+      }),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Retrieve node tests
+// ---------------------------------------------------------------------------
+
+describe("retrieve node", () => {
+  it("maps hits correctly to Retrieval objects", async () => {
+    const fakeHits = [
+      { _id: "chunk-1", _score: 0.92, fields: { text: "First chunk text." } },
+      { _id: "chunk-2", _score: 0.85, fields: { text: "Second chunk text." } },
+    ];
+
+    const vectorStore = makeVectorStoreMock(fakeHits);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const retrieveNode = createRetrieveNode(vectorStore as any);
+    const state = makeState();
+
+    const result = await retrieveNode(state);
+
+    expect(result.retrievals).toHaveLength(2);
+    expect(result.retrievals![0].chunkId).toBe("chunk-1");
+    expect(result.retrievals![0].text).toBe("First chunk text.");
+    expect(result.retrievals![0].score).toBe(0.92);
+    expect(result.retrievals![1].chunkId).toBe("chunk-2");
+    expect(result.retrievals![1].text).toBe("Second chunk text.");
+    expect(result.retrievals![1].score).toBe(0.85);
+  });
+
+  it("returns empty array when no hits are returned", async () => {
+    const vectorStore = makeVectorStoreMock([]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const retrieveNode = createRetrieveNode(vectorStore as any);
+    const state = makeState();
+
+    const result = await retrieveNode(state);
+
+    expect(result.retrievals).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Generate node tests
+// ---------------------------------------------------------------------------
+
+describe("generate node", () => {
+  it("includes chunk text in the prompt passed to the LLM", async () => {
+    const retrievals = [
+      { chunkId: "chunk-1", text: "Creditors must disclose APR.", score: 0.9 },
+    ];
+    const anthropic = makeAnthropicMock("The APR must be disclosed. [^1]");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const generateNode = createGenerateNode(anthropic as any);
+    const state = makeState({ retrievals });
+
+    await generateNode(state);
+
+    const call = anthropic.messages.create.mock.calls[0][0];
+    const userContent = call.messages[0].content as string;
+    expect(userContent).toContain("Creditors must disclose APR.");
+  });
+
+  it("parses citation markers from the answer and builds Citation objects", async () => {
+    const retrievals = [
+      { chunkId: "chunk-A", text: "First source text.", score: 0.95 },
+      { chunkId: "chunk-B", text: "Second source text.", score: 0.88 },
+    ];
+    const anthropic = makeAnthropicMock("See [^1] and [^2].");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const generateNode = createGenerateNode(anthropic as any);
+    const state = makeState({ retrievals });
+
+    const result = await generateNode(state);
+
+    expect(result.citations).toHaveLength(2);
+    expect(result.citations![0].chunkId).toBe("chunk-A");
+    expect(result.citations![0].marker).toBe("[^1]");
+    expect(result.citations![1].chunkId).toBe("chunk-B");
+    expect(result.citations![1].marker).toBe("[^2]");
+  });
+
+  it("handles empty retrievals gracefully", async () => {
+    const cannotAnswerText = "I cannot answer from the available sources.";
+    const anthropic = makeAnthropicMock(cannotAnswerText);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const generateNode = createGenerateNode(anthropic as any);
+    const state = makeState({ retrievals: [] });
+
+    const result = await generateNode(state);
+
+    expect(result.answer).toBe(cannotAnswerText);
+    expect(result.citations).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Wires the two-node LangGraph `StateGraph` backing the compliance copilot.

- `pipeline/state.ts` — `GraphStateAnnotation` via `Annotation.Root`; `retrievals` uses array reducer
- `pipeline/nodes/retrieve.ts` — `createRetrieveNode(vectorStore)` factory; calls Pinecone `searchRecords`, maps hits to `Retrieval[]`
- `pipeline/nodes/generate.ts` — `createGenerateNode(anthropic)` factory; grounded system prompt; `[^N]` citation parsing; `claude-haiku-4-5-20251001`
- `pipeline/graph.ts` — compiled `START → retrieve → generate → END`; exports `graph`
- `shared/types.ts` — `GraphState` interface removed; re-exported from `pipeline/state.ts`
- `tests/unit/pipeline.test.ts` — 5 mocked unit tests (14 total passing with existing chunk tests)

Reviewer APPROVED. `pnpm typecheck`, `pnpm lint`, and `pnpm test:unit` all pass.

Closes #11

https://claude.ai/code/session_013txQa93qg4oAA1GVouhvNg