### PR TITLE
Part 2 · Issue D — /api/query route handler

### DIFF
--- a/app/api/query/route.ts
+++ b/app/api/query/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { graph } from "../../../pipeline/graph";
+import type { Citation, Retrieval } from "../../../shared/types";
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const query =
+    body !== null &&
+    typeof body === "object" &&
+    "query" in body
+      ? (body as Record<string, unknown>).query
+      : undefined;
+
+  if (typeof query !== "string" || query.trim() === "") {
+    return NextResponse.json(
+      { error: "Missing or invalid query" },
+      { status: 400 },
+    );
+  }
+
+  let state: { answer?: string; citations?: Citation[]; retrievals?: Retrieval[] };
+  try {
+    state = await graph.invoke({ query });
+  } catch (err) {
+    console.error("[api/query] pipeline error:", err);
+    return NextResponse.json(
+      { error: "Internal pipeline error" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    answer: state.answer ?? "",
+    citations: state.citations ?? [],
+    retrievals: state.retrievals ?? [],
+  });
+}

--- a/tests/integration/query-route.test.ts
+++ b/tests/integration/query-route.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+
+describe.skipIf(!process.env.PINECONE_API_KEY || !process.env.ANTHROPIC_API_KEY)(
+  "/api/query route integration",
+  () => {
+    it("returns answer and citations for a compliance question", async () => {
+      // Import the POST handler directly (not via HTTP)
+      const { POST } = await import("../../app/api/query/route");
+      const req = new Request("http://localhost/api/query", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "What are the baseline requirements for cyber incident detection?" }),
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(typeof body.answer).toBe("string");
+      expect(body.answer.length).toBeGreaterThan(0);
+      expect(Array.isArray(body.citations)).toBe(true);
+    });
+  }
+);


### PR DESCRIPTION
## Summary

Thin Next.js POST route that exposes the LangGraph pipeline over HTTP.

- `app/api/query/route.ts` — parses `{ query }`, validates input (400), calls `graph.invoke`, returns `{ answer, citations, retrievals }` (500 on pipeline error)
- `tests/integration/query-route.test.ts` — skipped without both `PINECONE_API_KEY` and `ANTHROPIC_API_KEY`

Reviewer APPROVED. `pnpm typecheck`, `pnpm lint`, and `pnpm test:unit` all pass (14 tests, no regressions).

**Note:** Pre-existing bug in `tests/integration/ingest-roundtrip.test.ts` — skip guard only checks `PINECONE_API_KEY` but not `PINECONE_INDEX`, so it errors when the API key is in env but the index name isn't set. Predates this PR; should be fixed separately.

Closes #14

https://claude.ai/code/session_013txQa93qg4oAA1GVouhvNg