### PR TITLE
Issue #27: Citation-aware chunker (Part 3 M4 Issue C, code-complete)

### DIFF
--- a/ingest/ARCHITECTURE.md
+++ b/ingest/ARCHITECTURE.md
@@ -21,8 +21,15 @@ flowchart TD
 
     subgraph C[ingest/chunk.ts — chunkDocument]
         direction TB
-        C1[Split on H1/H2/H3<br/>headers] --> C2[Track heading path<br/>per section]
-        C2 --> C3[Pack sentences into<br/>~500-token chunks]
+        C0{authority?}
+        C0 -->|SEC / FINRA / MSRB| C_REG[Regulatory mode<br/>paragraph-aware]
+        C0 -->|Kestrel / FinCEN / …| C_FB[Fallback mode<br/>H1/H2/H3 + pack]
+        C_REG --> C1R[Track heading path<br/>+ paragraph marker stack]
+        C1R --> C2R[Emit 1 chunk per<br/>terminal paragraph]
+        C_FB --> C1[Split on H1/H2/H3 headers]
+        C1 --> C2[Track heading path<br/>per section]
+        C2R --> C3[Pack sentences into<br/>~500-token chunks]
+        C2 --> C3
         C3 --> C4[Add ~50-token<br/>overlap between chunks]
         C4 --> C5[Guard: never split<br/>mid-citation or mid-sentence]
     end
@@ -50,38 +57,54 @@ Every record in Pinecone is **flat** — no nested `metadata` object, no object 
 
 | Field | Type | Example |
 |---|---|---|
-| `id` | string | `12 CFR 1026.18::chunk_0` |
+| `id` | string | `17-CFR-240.15l-1::(a)(2)(ii)::p0` (regulatory) · `Kestrel-WSP-Equities::chunk_0` (fallback) |
 | `chunk_text` | string | chunk body (embedded by Pinecone via index `fieldMap`) |
-| `title` | string | `"CFPB Regulation Z — §1026.18"` |
-| `source` | string | `"CFPB"` |
-| `citation_id` | string | `"12 CFR 1026.18"` |
-| `jurisdiction` | string | `"US-Federal"` |
-| `doc_type` | string | `"regulation"` |
-| `effective_date` | string | `"2011-12-30"` |
-| `source_url` | string | canonical `.gov` URL |
+| `title` | string | `"Regulation Best Interest — 17 CFR 240.15l-1"` |
+| `source` | string | `"SEC"` |
+| `authority` | string | `"SEC"` / `"FINRA"` / `"MSRB"` / `"FinCEN"` / `"Kestrel"` |
+| `citation_id` | string | `"17-CFR-240.15l-1"` |
+| `jurisdiction` | string | `"US-Federal"` / `"SRO"` / `"Internal"` |
+| `doc_type` | string | `"regulation"` / `"rule"` / `"guidance"` / `"enforcement"` / `"internal"` / `"operational"` |
+| `effective_date` | string | `"2020-06-30"` |
+| `source_url` | string | canonical `.gov` / `.finra.org` URL or `internal://` scheme |
+| `version_status` | string | `"current"` / `"proposed"` / `"superseded"` |
+| `topic_tags` | string[] | `["best-interest", "retail-customers"]` |
 | `chunk_index` | number | `0` |
-| `heading_path` | string | `"Truth in Lending > Required disclosures"` |
+| `heading_path` | string | `"§ 240.15l-1 > (a) Best interest obligation > (2) Care obligation"` |
+| `paragraph_path` | string | `"(a)(2)(ii)"` (regulatory) · `""` (fallback) |
 
 ---
 
 ## Chunking strategy
 
-```mermaid
-flowchart LR
-    A[Raw markdown] --> B{Has headers?}
-    B -->|Yes| C[Split at H1/H2/H3<br/>boundaries]
-    B -->|No| D[Treat whole body<br/>as one section]
-    C --> E[Pack sentences<br/>~500 tokens each]
-    D --> E
-    E --> F[Slide 50-token<br/>overlap window]
-    F --> G[Chunk[]]
-```
+`chunkDocument` dispatches on `metadata.authority`:
+
+- **Regulatory mode** (`SEC`, `FINRA`, `MSRB`) — recognises paragraph markers
+  alongside H1/H2/H3 headers. SEC/CFR markers are `(a)` → `(1)` → `(i)`;
+  FINRA Supplementary Material markers are `.01`–`.99`; MSRB is `(a)` →
+  `(i)`. The chunker walks the body, tracks a heading stack and a paragraph
+  marker stack, and emits one chunk per terminal paragraph (the deepest
+  `(i)` / `(ii)` / `.NN` level containing prose). Ambiguous Roman-letter
+  markers (`(i)`, `(v)`, `(x)`, `(l)`, `(c)`) are resolved using the
+  current marker stack: inside a `(N)` they read as Roman numerals, at the
+  top level they read as letters.
+- **Fallback mode** (`Kestrel`, `FinCEN`, anything else) — the legacy
+  H1/H2/H3 + sentence-packing logic. Emits one chunk per heading section,
+  packed to the ~500-token budget.
+
+Within either mode, a frame whose prose exceeds the target token budget
+is split across multiple chunks via the sentence packer with ~50-token
+overlap between adjacent chunks.
 
 **Token heuristic:** `1 token ≈ 0.75 words` → target word budget = 375 words, overlap = 38 words.
 
-**Citation protection:** sentence splitter guards against splitting on `.` preceded by a digit or uppercase letter, preserving strings like `12 CFR 1026.18` and `U.S.C.` within a single chunk.
+**Citation protection:** sentence splitter guards against splitting on `.` preceded by a digit or uppercase letter, preserving strings like `17 CFR 240.15l-1` and `U.S.C.` within a single chunk.
 
-**ID format:** `${citationId}::chunk_${globalIndex}` — stable across re-runs, enabling idempotent upserts.
+**ID format:**
+- Regulatory: `${citationId}::${paragraphPath}::p${N}` (e.g. `FINRA-Rule-5310::.09::p0`).
+- Fallback: `${citationId}::chunk_${globalIndex}` (unchanged).
+
+Both formats are stable across re-runs, enabling idempotent upserts.
 
 ---
 

--- a/ingest/chunk.ts
+++ b/ingest/chunk.ts
@@ -1,13 +1,23 @@
 /**
- * Markdown-aware chunker.
+ * Markdown-aware chunker with regulatory paragraph-path awareness.
  *
- * Strategy:
- * 1. Split on H1/H2/H3 header boundaries.
- * 2. Carry the full heading path for each section.
- * 3. Pack sub-sections into chunks of ~500 tokens (~375 words) with ~50-token
- *    (~38-word) overlap.
- * 4. Never split mid-citation (e.g. `12 CFR 1026.18`) or mid-sentence.
- * 5. Token heuristic: 1 token ≈ 0.75 words  ↔  N tokens ≈ N * 0.75 words.
+ * Two modes, dispatched on the front-matter `authority`:
+ *
+ *  - **Regulatory mode** (`authority ∈ {SEC, FINRA, MSRB}`): the chunker
+ *    recognises paragraph markers in the body — (a), (1), (i) for CFR-style
+ *    regulations and .01-.99 for FINRA Supplementary Material — and emits
+ *    one chunk per terminal paragraph. Chunk IDs are
+ *    `${citationId}::${paragraphPath}::p${N}`.
+ *
+ *  - **Fallback mode** (everything else, including `Kestrel` and `FinCEN`):
+ *    the original H1/H2/H3 + sentence-packing logic. Chunk IDs remain
+ *    `${citationId}::chunk_${N}`.
+ *
+ * Shared behaviour across modes:
+ *  - Target ~500 tokens (~375 words) per chunk, with ~50-token (~38-word)
+ *    overlap between adjacent chunks within the same leaf.
+ *  - Never split mid-sentence or mid-citation (e.g. `12 CFR 1026.18`).
+ *  - Token heuristic: 1 token ≈ 0.75 words.
  */
 
 import type { Chunk, ChunkMetadata } from "../shared/types";
@@ -18,35 +28,21 @@ import type { Chunk, ChunkMetadata } from "../shared/types";
 
 const TARGET_TOKENS = 500;
 const OVERLAP_TOKENS = 50;
-// 1 token ≈ 0.75 words  ⟹  word budget = token budget × 0.75
 const WORDS_PER_TOKEN = 0.75;
 const TARGET_WORDS = Math.round(TARGET_TOKENS * WORDS_PER_TOKEN); // ~375
 const OVERLAP_WORDS = Math.round(OVERLAP_TOKENS * WORDS_PER_TOKEN); // ~38
 
-// Regex matching H1 / H2 / H3 lines (including the newline that follows).
-const HEADER_RE = /^(#{1,3})\s+(.+)$/m;
+const HEADER_RE = /^(#{1,3})\s+(.+)$/;
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Sentence-level helpers (shared across modes)
 // ---------------------------------------------------------------------------
 
-/** Rough word count. */
 function wordCount(text: string): number {
   return text.trim().split(/\s+/).filter(Boolean).length;
 }
 
-/**
- * Split `text` into sentences while preserving citation strings such as
- * `12 CFR 1026.18`.  A citation is any token matching the pattern
- * `NN+ [A-Z]+ NNN+` (e.g. "12 CFR 1026.18", "15 U.S.C. 1601").
- *
- * The split is performed on `. `, `! `, `? ` that are NOT preceded by a
- * citation-like sequence.
- */
 function splitSentences(text: string): string[] {
-  // We split on sentence-ending punctuation followed by whitespace, but we
-  // must not split inside a citation such as "12 CFR 1026.18" or "15 U.S.C."
-  // Strategy: walk character-by-character and find safe split points.
   const sentences: string[] = [];
   let start = 0;
 
@@ -55,15 +51,11 @@ function splitSentences(text: string): string[] {
     if ((ch === "." || ch === "!" || ch === "?") && i + 1 < text.length) {
       const next = text[i + 1];
       if (next === " " || next === "\n") {
-        // Check if this period is part of a citation / abbreviation.
-        // Look back for a digit immediately before the dot.
         const prevChar = i > 0 ? text[i - 1] : "";
         const isCitationDot = /\d/.test(prevChar);
-        // Also guard abbreviations like "U.S.C." — uppercase letter before dot.
         const isAbbrev = /[A-Z]/.test(prevChar);
         if (!isCitationDot && !isAbbrev) {
           sentences.push(text.slice(start, i + 1).trim());
-          // Skip the whitespace(s) after the punctuation.
           while (i + 1 < text.length && /\s/.test(text[i + 1])) i++;
           start = i + 1;
         }
@@ -75,73 +67,6 @@ function splitSentences(text: string): string[] {
   return sentences.filter((s) => s.length > 0);
 }
 
-// ---------------------------------------------------------------------------
-// Section parsing
-// ---------------------------------------------------------------------------
-
-interface Section {
-  headingPath: string;
-  body: string;
-}
-
-/**
- * Parse the markdown `body` into sections delimited by H1/H2/H3 headers.
- * Each section carries its full heading path, e.g.
- *   "Domain 5 > Incident Resilience Planning and Strategy > Testing"
- */
-function parseSections(body: string): Section[] {
-  // Split on lines that start with 1-3 `#` characters.
-  const lines = body.split("\n");
-  const sections: Section[] = [];
-
-  // Track the heading hierarchy: index 0 = H1, 1 = H2, 2 = H3.
-  const headingStack: string[] = ["", "", ""];
-
-  let currentHeadingPath = "";
-  let currentBodyLines: string[] = [];
-
-  function flush() {
-    const text = currentBodyLines.join("\n").trim();
-    if (text.length > 0 || sections.length === 0) {
-      sections.push({ headingPath: currentHeadingPath, body: text });
-    }
-    currentBodyLines = [];
-  }
-
-  for (const line of lines) {
-    const match = HEADER_RE.exec(line);
-    if (match) {
-      flush();
-      const level = match[1].length; // 1, 2, or 3
-      const title = match[2].trim();
-
-      // Update heading stack.
-      headingStack[level - 1] = title;
-      // Clear deeper levels.
-      for (let d = level; d < headingStack.length; d++) {
-        headingStack[d] = "";
-      }
-
-      currentHeadingPath = headingStack
-        .filter((h) => h.length > 0)
-        .join(" > ");
-    } else {
-      currentBodyLines.push(line);
-    }
-  }
-  flush();
-
-  return sections;
-}
-
-// ---------------------------------------------------------------------------
-// Packing sections into chunks
-// ---------------------------------------------------------------------------
-
-/**
- * Given a list of sentences, produce chunks respecting the word budget with
- * overlap.  Never splits mid-sentence.
- */
 function packSentencesIntoChunks(sentences: string[]): string[] {
   if (sentences.length === 0) return [];
 
@@ -153,11 +78,8 @@ function packSentencesIntoChunks(sentences: string[]): string[] {
     const sw = wordCount(sentence);
 
     if (currentWords + sw > TARGET_WORDS && currentSentences.length > 0) {
-      // Emit the current chunk.
       chunks.push(currentSentences.join(" "));
 
-      // Build the overlap: keep sentences from the end of the current chunk
-      // until we have ~OVERLAP_WORDS worth.
       const overlapSentences: string[] = [];
       let overlapWords = 0;
       for (let i = currentSentences.length - 1; i >= 0; i--) {
@@ -183,17 +105,55 @@ function packSentencesIntoChunks(sentences: string[]): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Fallback mode: H1/H2/H3 + sentence-packing (Kestrel, FinCEN, unknown)
 // ---------------------------------------------------------------------------
 
-/**
- * Chunk a markdown document body into `Chunk[]` records.
- *
- * @param body     - The markdown body (after front-matter has been stripped).
- * @param metadata - The base metadata for this document (from front-matter).
- *                   `headingPath` and `chunkIndex` will be overwritten per chunk.
- */
-export function chunkDocument(
+interface Section {
+  headingPath: string;
+  body: string;
+}
+
+function parseSections(body: string): Section[] {
+  const lines = body.split("\n");
+  const sections: Section[] = [];
+  const headingStack: string[] = ["", "", ""];
+
+  let currentHeadingPath = "";
+  let currentBodyLines: string[] = [];
+
+  function flush() {
+    const text = currentBodyLines.join("\n").trim();
+    if (text.length > 0 || sections.length === 0) {
+      sections.push({ headingPath: currentHeadingPath, body: text });
+    }
+    currentBodyLines = [];
+  }
+
+  for (const line of lines) {
+    const match = HEADER_RE.exec(line);
+    if (match) {
+      flush();
+      const level = match[1].length;
+      const title = match[2].trim();
+
+      headingStack[level - 1] = title;
+      for (let d = level; d < headingStack.length; d++) {
+        headingStack[d] = "";
+      }
+
+      currentHeadingPath = headingStack
+        .filter((h) => h.length > 0)
+        .join(" > ");
+    } else {
+      currentBodyLines.push(line);
+    }
+  }
+  flush();
+
+  return sections;
+}
+
+function chunkFallback(
   body: string,
   metadata: Omit<ChunkMetadata, "headingPath" | "chunkIndex" | "paragraphPath">
 ): Chunk[] {
@@ -227,8 +187,6 @@ export function chunkDocument(
     }
   }
 
-  // If nothing was produced (e.g. body had no text in any section), fall back
-  // to treating the whole body as one chunk.
   if (chunks.length === 0 && body.trim().length > 0) {
     const chunkMetadata: ChunkMetadata = {
       ...metadata,
@@ -244,4 +202,275 @@ export function chunkDocument(
   }
 
   return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Regulatory mode: paragraph-marker detection
+// ---------------------------------------------------------------------------
+
+interface ParagraphMarker {
+  level: number;
+  marker: string;
+}
+
+type MarkerMatcher = (
+  line: string,
+  stack: readonly ParagraphMarker[]
+) => ParagraphMarker | null;
+
+// Single-char letters that are also valid Roman numerals (lowercase).
+// At the top level of an SEC/MSRB paragraph stack these read as letters
+// (e.g. `(i)` as a top-level paragraph). Inside a deeper numbered paragraph
+// they read as Roman numerals.
+const AMBIGUOUS_ROMAN_LETTER = /^[ivxlc]$/;
+
+// Strip Markdown leaders that commonly precede a paragraph marker: header
+// hashes, bullet points, numbered-list leaders, and any trailing whitespace.
+function stripLeaders(line: string): string {
+  return line.replace(/^(?:#{1,6}\s+|[-*]\s+|\d+\.\s+)/, "").trimStart();
+}
+
+// Prefer the Roman-numeral interpretation of an ambiguous single-char
+// letter (i, v, x, l, c) when the paragraph stack is already inside a
+// numbered sub-paragraph — the CFR convention is (a) → (1) → (i).
+function preferRomanHere(stack: readonly ParagraphMarker[]): boolean {
+  return stack.some((m) => m.level === 1);
+}
+
+function matchSecMarker(
+  line: string,
+  stack: readonly ParagraphMarker[]
+): ParagraphMarker | null {
+  const s = stripLeaders(line);
+
+  // Multi-char Roman (ii, iii, iv, vi, ix, …) is unambiguous.
+  let m = s.match(/^\(([ivxlc]{2,})\)(?=\s|$|\.)/);
+  if (m) return { level: 2, marker: `(${m[1]})` };
+
+  // Single-letter marker: ambiguous iff the letter is itself a valid
+  // Roman-numeral symbol. Resolve by stack context.
+  m = s.match(/^\(([a-z])\)(?=\s|$|\.)/);
+  if (m) {
+    const letter = m[1];
+    if (AMBIGUOUS_ROMAN_LETTER.test(letter) && preferRomanHere(stack)) {
+      return { level: 2, marker: `(${letter})` };
+    }
+    return { level: 0, marker: `(${letter})` };
+  }
+
+  m = s.match(/^\((\d+)\)(?=\s|$|\.)/);
+  if (m) return { level: 1, marker: `(${m[1]})` };
+  return null;
+}
+
+function matchFinraMarker(line: string): ParagraphMarker | null {
+  const s = stripLeaders(line);
+  const m = s.match(/^\.(\d{2})(?=\s|$)/);
+  if (m) return { level: 0, marker: `.${m[1]}` };
+  return null;
+}
+
+function matchMsrbMarker(
+  line: string,
+  stack: readonly ParagraphMarker[]
+): ParagraphMarker | null {
+  const s = stripLeaders(line);
+
+  // Multi-char Roman is unambiguous.
+  let m = s.match(/^\(([ivxlc]{2,})\)(?=\s|$|\.)/);
+  if (m) return { level: 1, marker: `(${m[1]})` };
+
+  m = s.match(/^\(([a-z])\)(?=\s|$|\.)/);
+  if (m) {
+    const letter = m[1];
+    // MSRB uses two levels: (a) then (i). Inside an (a), ambiguous letters
+    // resolve as Roman.
+    if (
+      AMBIGUOUS_ROMAN_LETTER.test(letter) &&
+      stack.some((p) => p.level === 0)
+    ) {
+      return { level: 1, marker: `(${letter})` };
+    }
+    return { level: 0, marker: `(${letter})` };
+  }
+  return null;
+}
+
+// Strip a detected paragraph marker from the line's rendered text, keeping
+// any prose that follows it on the same line.
+function stripDetectedMarker(line: string): string {
+  // Strip leading Markdown leader once, then strip the paragraph marker.
+  const noLeader = line.replace(/^(?:#{1,6}\s+|[-*]\s+|\d+\.\s+)/, "");
+  return noLeader
+    .replace(/^\.(\d{2})\s*/, "")
+    .replace(/^\(([a-z0-9]+|[ivxlc]+)\)\s*/i, "")
+    .trim();
+}
+
+interface ParagraphFrame {
+  paragraphPath: string; // concatenation of marker stack, e.g. "(a)(2)(ii)"
+  headingPath: string;
+  lines: string[];
+}
+
+function chunkRegulatory(
+  body: string,
+  metadata: Omit<ChunkMetadata, "headingPath" | "chunkIndex" | "paragraphPath">,
+  matcher: MarkerMatcher
+): Chunk[] {
+  const lines = body.split("\n");
+  const headingStack: string[] = ["", "", ""];
+  const markerStack: ParagraphMarker[] = [];
+  const frames: ParagraphFrame[] = [];
+  let current: ParagraphFrame = { paragraphPath: "", headingPath: "", lines: [] };
+
+  function pathFromStack(): string {
+    return markerStack.map((m) => m.marker).join("");
+  }
+
+  function currentHeadingPath(): string {
+    return headingStack.filter((h) => h.length > 0).join(" > ");
+  }
+
+  function openFrame(): void {
+    current = {
+      paragraphPath: pathFromStack(),
+      headingPath: currentHeadingPath(),
+      lines: [],
+    };
+  }
+
+  function closeFrame(): void {
+    if (current.lines.some((l) => l.trim().length > 0)) {
+      frames.push(current);
+    }
+    openFrame();
+  }
+
+  for (const line of lines) {
+    const hdr = HEADER_RE.exec(line);
+    if (hdr) {
+      // Always close the current frame on a header boundary.
+      closeFrame();
+
+      const level = hdr[1].length;
+      headingStack[level - 1] = hdr[2].trim();
+      for (let d = level; d < headingStack.length; d++) headingStack[d] = "";
+
+      // Header may itself introduce a paragraph marker.
+      const headerMarker = matcher(line, markerStack);
+      if (headerMarker) {
+        while (
+          markerStack.length > 0 &&
+          markerStack[markerStack.length - 1].level >= headerMarker.level
+        ) {
+          markerStack.pop();
+        }
+        markerStack.push(headerMarker);
+      } else {
+        // A non-marker header resets the paragraph stack.
+        markerStack.length = 0;
+      }
+
+      openFrame();
+
+      // If the header introduces a paragraph marker, its trailing prose
+      // is the first sentence of that paragraph. Headers without a marker
+      // are purely structural — their title is not treated as chunk prose.
+      if (headerMarker) {
+        const residual = stripDetectedMarker(line);
+        if (residual.length > 0) current.lines.push(residual);
+      }
+      continue;
+    }
+
+    const marker = matcher(line, markerStack);
+    if (marker) {
+      closeFrame();
+      while (
+        markerStack.length > 0 &&
+        markerStack[markerStack.length - 1].level >= marker.level
+      ) {
+        markerStack.pop();
+      }
+      markerStack.push(marker);
+      openFrame();
+      const residual = stripDetectedMarker(line);
+      if (residual.length > 0) current.lines.push(residual);
+      continue;
+    }
+
+    current.lines.push(line);
+  }
+  closeFrame();
+
+  // Convert frames to chunks. A frame may produce multiple chunks if its
+  // prose exceeds the target-token budget; suffix with `p${N}` in order.
+  const chunks: Chunk[] = [];
+  let globalIndex = 0;
+
+  for (const frame of frames) {
+    const text = frame.lines.join("\n").trim();
+    if (text.length === 0) continue;
+
+    const sentences = splitSentences(text);
+    const packed = packSentencesIntoChunks(sentences);
+
+    for (let i = 0; i < packed.length; i++) {
+      const chunkText = packed[i];
+      if (chunkText.trim().length === 0) continue;
+
+      const chunkMetadata: ChunkMetadata = {
+        ...metadata,
+        headingPath: frame.headingPath,
+        paragraphPath: frame.paragraphPath,
+        chunkIndex: globalIndex,
+      };
+
+      const id =
+        frame.paragraphPath.length > 0
+          ? `${metadata.citationId}::${frame.paragraphPath}::p${i}`
+          : `${metadata.citationId}::chunk_${globalIndex}`;
+
+      chunks.push({ id, text: chunkText, metadata: chunkMetadata });
+      globalIndex++;
+    }
+  }
+
+  if (chunks.length === 0 && body.trim().length > 0) {
+    chunks.push({
+      id: `${metadata.citationId}::chunk_0`,
+      text: body.trim(),
+      metadata: {
+        ...metadata,
+        headingPath: "",
+        paragraphPath: "",
+        chunkIndex: 0,
+      },
+    });
+  }
+
+  return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function chunkDocument(
+  body: string,
+  metadata: Omit<ChunkMetadata, "headingPath" | "chunkIndex" | "paragraphPath">
+): Chunk[] {
+  switch (metadata.authority) {
+    case "SEC":
+      return chunkRegulatory(body, metadata, matchSecMarker);
+    case "FINRA":
+      return chunkRegulatory(body, metadata, (line) => matchFinraMarker(line));
+    case "MSRB":
+      return chunkRegulatory(body, metadata, matchMsrbMarker);
+    case "FinCEN":
+    case "Kestrel":
+    default:
+      return chunkFallback(body, metadata);
+  }
 }

--- a/tests/integration/ingest-roundtrip.test.ts
+++ b/tests/integration/ingest-roundtrip.test.ts
@@ -24,10 +24,12 @@ describe.skipIf(!hasCreds)("Ingest round-trip (requires Pinecone creds)", () => 
       const apiKey = process.env["PINECONE_API_KEY"]!;
       const pc = new Pinecone({ apiKey });
 
-      // Ingest the corpus file.
+      // Ingest a regulatory corpus file — exercises the citation-aware
+      // chunker path. The expected pinpoint is FINRA Rule 5310
+      // Supplementary Material .09 (best execution for fixed income).
       const corpusPath = resolve(
         process.cwd(),
-        "corpus/archive/v1/ffiec-cat-domain-5.md"
+        "corpus/finra-5310-best-execution.md"
       );
       const raw = readFileSync(corpusPath, "utf8");
       const { data: frontMatter, content: markdownBody } = matter(raw);
@@ -68,7 +70,7 @@ describe.skipIf(!hasCreds)("Ingest round-trip (requires Pinecone creds)", () => 
 
       // Poll until the record is searchable (up to 5 attempts × 2 s).
       const index = pc.index(indexName);
-      const knownSubstring = "cyber incident";
+      const knownSubstring = "best execution for fixed income";
       let topHitId: string | undefined;
 
       for (let attempt = 0; attempt < 5; attempt++) {
@@ -89,7 +91,9 @@ describe.skipIf(!hasCreds)("Ingest round-trip (requires Pinecone creds)", () => 
       }
 
       expect(topHitId).toBeDefined();
-      expect(topHitId).toMatch(/^FFIEC-CAT-Domain-5::chunk_/);
+      // Chunk IDs for regulatory (FINRA) docs use the citation-aware format
+      // `${citationId}::${paragraphPath}::p${N}`.
+      expect(topHitId).toMatch(/^FINRA-Rule-5310::\.\d{2}::p\d+$/);
     },
     60_000 // 60 s timeout for network calls + polling
   );

--- a/tests/unit/chunk-fallback.test.ts
+++ b/tests/unit/chunk-fallback.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Fallback-mode regression: Kestrel (internal) docs should use the legacy
+ * H1/H2/H3 + sentence-packing chunker, with chunk IDs of the form
+ * `${citationId}::chunk_${N}` — not the regulatory `::${path}::p${N}` form.
+ */
+
+import { describe, it, expect } from "vitest";
+import { chunkDocument } from "../../ingest/chunk";
+import type { ChunkMetadata } from "../../shared/types";
+
+const KESTREL_METADATA: Omit<
+  ChunkMetadata,
+  "headingPath" | "chunkIndex" | "paragraphPath"
+> = {
+  title: "Kestrel WSP — Equities",
+  source: "Kestrel Securities",
+  authority: "Kestrel",
+  citationId: "Kestrel-WSP-Equities",
+  jurisdiction: "Internal",
+  docType: "internal",
+  effectiveDate: "2025-07-01",
+  sourceUrl: "internal://kestrel/policies/wsp/equities.md",
+  versionStatus: "current",
+  topicTags: ["wsp", "equities"],
+};
+
+// A Kestrel-flavoured body that happens to contain something that *looks*
+// like a CFR marker — the regulatory-mode matchers would detect it, but
+// fallback-mode should not.
+const FIXTURE_KESTREL = `
+# Kestrel Securities — WSP: Equities Trading Desk
+
+## 1. Purpose
+
+These procedures implement Kestrel's supervisory system under FINRA Rule
+3110. They apply to all associated persons of the desk.
+
+## 2. Order entry
+
+All customer orders are time-stamped on receipt and entered into the OMS
+within 60 seconds. Phone orders receive a same-day review.
+`.trim();
+
+describe("Fallback mode for Kestrel internal docs", () => {
+  it("produces chunk IDs of the form `Kestrel-WSP-Equities::chunk_N`", () => {
+    const chunks = chunkDocument(FIXTURE_KESTREL, KESTREL_METADATA);
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const chunk of chunks) {
+      expect(chunk.id).toMatch(/^Kestrel-WSP-Equities::chunk_\d+$/);
+    }
+  });
+
+  it("assigns an empty paragraphPath to fallback chunks", () => {
+    const chunks = chunkDocument(FIXTURE_KESTREL, KESTREL_METADATA);
+    for (const chunk of chunks) {
+      expect(chunk.metadata.paragraphPath).toBe("");
+    }
+  });
+
+  it("still populates headingPath from H1/H2 headers", () => {
+    const chunks = chunkDocument(FIXTURE_KESTREL, KESTREL_METADATA);
+    const hasNested = chunks.some((c) =>
+      c.metadata.headingPath.includes("Kestrel Securities")
+    );
+    expect(hasNested).toBe(true);
+  });
+});
+
+describe("Fallback mode for FinCEN docs", () => {
+  it("also uses the legacy chunk_N ID format", () => {
+    const meta: Omit<
+      ChunkMetadata,
+      "headingPath" | "chunkIndex" | "paragraphPath"
+    > = {
+      ...KESTREL_METADATA,
+      authority: "FinCEN",
+      citationId: "31-CFR-Part-1023",
+      jurisdiction: "US-Federal",
+      docType: "regulation",
+    };
+    const chunks = chunkDocument(FIXTURE_KESTREL, meta);
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const chunk of chunks) {
+      expect(chunk.id).toMatch(/^31-CFR-Part-1023::chunk_\d+$/);
+    }
+  });
+});

--- a/tests/unit/chunk.test.ts
+++ b/tests/unit/chunk.test.ts
@@ -243,3 +243,132 @@ describe("Invariant 5: no-header document produces at least one chunk", () => {
     expect(chunks[0].id).toBe("TEST-DOC::chunk_0");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regulatory mode: SEC (CFR) paragraph markers
+// ---------------------------------------------------------------------------
+
+const FIXTURE_SEC_CFR = `
+# § 240.15l-1 Regulation Best Interest.
+
+## (a) Best interest obligation.
+
+A broker-dealer must act in the best interest of the retail customer at the
+time the recommendation is made, without placing the broker-dealer's
+interest ahead of the customer's.
+
+### (2) Care obligation.
+
+The broker-dealer must exercise reasonable diligence, care, and skill.
+
+- (ii) Have a reasonable basis to believe that the recommendation is in the
+  best interest of a particular retail customer based on that customer's
+  investment profile.
+`.trim();
+
+describe("Regulatory mode: SEC CFR paragraph paths", () => {
+  const SEC_METADATA: Omit<
+    ChunkMetadata,
+    "headingPath" | "chunkIndex" | "paragraphPath"
+  > = {
+    ...BASE_METADATA,
+    authority: "SEC",
+    citationId: "17-CFR-240.15l-1",
+  };
+
+  it("emits a chunk with ID `17-CFR-240.15l-1::(a)(2)(ii)::p0`", () => {
+    const chunks = chunkDocument(FIXTURE_SEC_CFR, SEC_METADATA);
+    const ids = chunks.map((c) => c.id);
+    expect(ids).toContain("17-CFR-240.15l-1::(a)(2)(ii)::p0");
+  });
+
+  it("assigns paragraph paths at (a), (a)(2), and (a)(2)(ii)", () => {
+    const chunks = chunkDocument(FIXTURE_SEC_CFR, SEC_METADATA);
+    const paths = new Set(chunks.map((c) => c.metadata.paragraphPath));
+    expect(paths.has("(a)")).toBe(true);
+    expect(paths.has("(a)(2)")).toBe(true);
+    expect(paths.has("(a)(2)(ii)")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regulatory mode: FINRA Supplementary Material markers
+// ---------------------------------------------------------------------------
+
+const FIXTURE_FINRA = `
+# Rule 5310. Best Execution and Interpositioning
+
+## (a) Best execution standard.
+
+A member shall use reasonable diligence to ascertain the best market.
+
+# Supplementary Material
+
+## .09 Best Execution for Fixed Income Securities.
+
+For debt securities that are subject to FINRA jurisdiction, the
+best-execution review must be conducted in a manner that accounts for
+the distinct characteristics of the fixed-income markets.
+`.trim();
+
+describe("Regulatory mode: FINRA Supplementary Material paths", () => {
+  const FINRA_METADATA: Omit<
+    ChunkMetadata,
+    "headingPath" | "chunkIndex" | "paragraphPath"
+  > = {
+    ...BASE_METADATA,
+    authority: "FINRA",
+    citationId: "FINRA-Rule-5310",
+    jurisdiction: "SRO",
+    docType: "rule",
+  };
+
+  it("emits a chunk with ID `FINRA-Rule-5310::.09::p0`", () => {
+    const chunks = chunkDocument(FIXTURE_FINRA, FINRA_METADATA);
+    const ids = chunks.map((c) => c.id);
+    expect(ids).toContain("FINRA-Rule-5310::.09::p0");
+  });
+
+  it("recognises both the operative (a) paragraph and the .09 Supplementary Material", () => {
+    const chunks = chunkDocument(FIXTURE_FINRA, FINRA_METADATA);
+    const paths = new Set(chunks.map((c) => c.metadata.paragraphPath));
+    // FINRA matcher doesn't match `(a)` — only `.NN` — so (a) content
+    // falls through with an empty paragraph path.
+    expect(paths.has(".09")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regulatory mode: MSRB paragraph markers
+// ---------------------------------------------------------------------------
+
+const FIXTURE_MSRB = `
+# MSRB Rule G-18. Best Execution of Transactions in Municipal Securities.
+
+## (c) Considerations.
+
+In any transaction for or with a customer, a broker, dealer, or municipal
+securities dealer must use reasonable diligence.
+
+- (i) The character of the market for the security, including price,
+  volatility, and liquidity.
+`.trim();
+
+describe("Regulatory mode: MSRB paragraph paths", () => {
+  const MSRB_METADATA: Omit<
+    ChunkMetadata,
+    "headingPath" | "chunkIndex" | "paragraphPath"
+  > = {
+    ...BASE_METADATA,
+    authority: "MSRB",
+    citationId: "MSRB-Rule-G-18",
+    jurisdiction: "SRO",
+    docType: "rule",
+  };
+
+  it("emits a chunk with ID `MSRB-Rule-G-18::(c)(i)::p0`", () => {
+    const chunks = chunkDocument(FIXTURE_MSRB, MSRB_METADATA);
+    const ids = chunks.map((c) => c.id);
+    expect(ids).toContain("MSRB-Rule-G-18::(c)(i)::p0");
+  });
+});

--- a/tests/unit/retrieve.test.ts
+++ b/tests/unit/retrieve.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit test for pipeline/nodes/retrieve.ts — verifies that hits returned
+ * by the Pinecone search API are correctly hydrated into the v2
+ * `ChunkMetadata` shape, including the fields added in M4 Issue A
+ * (`authority`, `versionStatus`, `topicTags`, `paragraphPath`).
+ */
+
+import { describe, it, expect } from "vitest";
+import { createRetrieveNode } from "../../pipeline/nodes/retrieve";
+import type { GraphState } from "../../pipeline/state";
+
+// Minimal shape matching what pipeline/nodes/retrieve.ts uses from Pinecone.
+type FakeHit = {
+  _id: string;
+  _score: number;
+  fields: Record<string, unknown>;
+};
+
+function makeFakeIndex(hits: FakeHit[]) {
+  return {
+    searchRecords: async () => ({ result: { hits } }),
+    // The retrieve node only calls searchRecords — other Pinecone methods
+    // on the index proxy are not exercised here.
+  } as unknown as Parameters<typeof createRetrieveNode>[0];
+}
+
+describe("pipeline/nodes/retrieve — v2 metadata hydration", () => {
+  it("populates authority, versionStatus, topicTags, and paragraphPath from hit fields", async () => {
+    const hits: FakeHit[] = [
+      {
+        _id: "17-CFR-240.15l-1::(a)(2)(ii)::p0",
+        _score: 0.91,
+        fields: {
+          title: "Reg BI",
+          source: "SEC",
+          authority: "SEC",
+          citation_id: "17-CFR-240.15l-1",
+          jurisdiction: "US-Federal",
+          doc_type: "regulation",
+          effective_date: "2020-06-30",
+          source_url: "https://example.gov/reg-bi",
+          version_status: "current",
+          topic_tags: ["best-interest", "retail-customers"],
+          heading_path: "§ 240.15l-1 > (a) > (2)",
+          paragraph_path: "(a)(2)(ii)",
+          chunk_index: 0,
+          chunk_text: "The broker-dealer must have a reasonable basis…",
+        },
+      },
+    ];
+
+    const node = createRetrieveNode(makeFakeIndex(hits));
+    const out = (await node({
+      query: "best-interest recommendations",
+      retrievals: [],
+    } as unknown as GraphState)) as Partial<GraphState>;
+
+    expect(out.retrievals).toBeDefined();
+    const r = out.retrievals![0];
+    expect(r.chunkId).toBe("17-CFR-240.15l-1::(a)(2)(ii)::p0");
+    expect(r.metadata?.authority).toBe("SEC");
+    expect(r.metadata?.versionStatus).toBe("current");
+    expect(r.metadata?.topicTags).toEqual([
+      "best-interest",
+      "retail-customers",
+    ]);
+    expect(r.metadata?.paragraphPath).toBe("(a)(2)(ii)");
+    expect(r.metadata?.headingPath).toBe("§ 240.15l-1 > (a) > (2)");
+  });
+
+  it("applies safe defaults for legacy records missing v2 fields", async () => {
+    const hits: FakeHit[] = [
+      {
+        _id: "legacy-record::chunk_0",
+        _score: 0.5,
+        fields: {
+          title: "Legacy",
+          source: "Internal",
+          citation_id: "legacy-record",
+          jurisdiction: "Internal",
+          doc_type: "internal",
+          effective_date: "2024-01-01",
+          source_url: "internal://legacy",
+          heading_path: "A > B",
+          chunk_index: 0,
+          chunk_text: "Old record body.",
+          // authority, version_status, topic_tags, paragraph_path intentionally absent
+        },
+      },
+    ];
+
+    const node = createRetrieveNode(makeFakeIndex(hits));
+    const out = (await node({
+      query: "legacy",
+      retrievals: [],
+    } as unknown as GraphState)) as Partial<GraphState>;
+
+    const r = out.retrievals![0];
+    // Defaults defined in pipeline/nodes/retrieve.ts.
+    expect(r.metadata?.authority).toBe("Kestrel");
+    expect(r.metadata?.versionStatus).toBe("current");
+    expect(r.metadata?.topicTags).toEqual([]);
+    expect(r.metadata?.paragraphPath).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- Rewrites `ingest/chunk.ts` with a dispatching chunker. Regulatory mode (SEC/FINRA/MSRB) walks the body line by line, recognises paragraph markers alongside H1/H2/H3 headers, tracks heading and paragraph stacks, and emits one chunk per terminal paragraph with IDs of the form `${citationId}::${paragraphPath}::p${N}`. Fallback mode (Kestrel/FinCEN/anything else) preserves the legacy H1/H2/H3 + sentence-packing behaviour with `::chunk_N` IDs.
- Handles the SEC/MSRB `(i)` ambiguity (single-letter Roman vs. single-letter paragraph) by consulting the current marker stack.
- Extends tests: per-authority fixtures asserting the expected chunk IDs (`17-CFR-240.15l-1::(a)(2)(ii)::p0`, `FINRA-Rule-5310::.09::p0`, `MSRB-Rule-G-18::(c)(i)::p0`), a fallback regression for Kestrel internal docs, and a retrieve-hydration test that fakes a Pinecone hit and asserts all v2 metadata fields are populated (with safe defaults for legacy records).
- Re-points the integration test at `corpus/finra-5310-best-execution.md` and asserts a citation-aware chunk ID pattern.
- Updates `ingest/ARCHITECTURE.md` with the v2 record-schema table and the two-mode chunking-strategy section.

## Scope note
This PR is **code-complete for Issue #27** but stops short of the ingest-side acceptance criterion (#3: "`pnpm ingest` against `kestrel-v2` completes without errors; JSON summary printed"). Creating the `kestrel-v2` Pinecone index and running `pnpm ingest` against it are deferred — they create cloud resources in the Pinecone account and should be confirmed before execution. Once the index is created (single command via the Pinecone console or API), `PINECONE_INDEX=kestrel-v2 pnpm ingest` should complete without code changes.

## Test plan
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [x] `pnpm test tests/unit` — 25/25 pass across 4 test files
- [x] SEC, FINRA, MSRB fixtures each produce the expected chunk IDs
- [x] Kestrel fixture produces `::chunk_N` IDs (fallback mode preserved)
- [x] Retrieve node hydrates `authority`, `versionStatus`, `topicTags`, and `paragraphPath` from Pinecone hit fields
- [ ] `pnpm ingest` against `kestrel-v2` — deferred (creates Pinecone resources)
- [ ] `pnpm test:integration` — deferred until `kestrel-v2` is populated

Closes #27 on the code-complete dimension; a follow-up will record the first real ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)