### PR TITLE
AGENT: eval pilot harness (pnpm eval, 10 items, pinpoint_precision@5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 # Claude local
 .claude/settings.local.json
 .claude/worktrees/
+
+# Eval results — per-run artifacts; the benchmark itself is committed.
+eval/results/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ pnpm build       # production build
 pnpm format      # prettier --write .
 ```
 
+## Evaluation
+
+`pnpm eval` runs the pilot benchmark (`eval/benchmarks/pilot.yaml`) — 10
+hand-labeled queries against the live Kestrel v2 corpus — through the same
+compiled graph the app uses, computes `pinpoint_precision@5` per item plus
+the overall mean, and writes a markdown report to
+`eval/results/<date>-<sha>.md` (also printed to stdout). The pilot is
+deliberately small; faithfulness, refusal, and CI gating land in the
+follow-up tickets E1–E5. See [`eval-plan.md`](./eval-plan.md) for the wider
+roadmap.
+
 ## Folder layout
 
 See [`plan.md` § Folders](./plan.md) for the full planned structure. The current skeleton is:

--- a/eval/benchmarks/pilot.yaml
+++ b/eval/benchmarks/pilot.yaml
@@ -1,0 +1,63 @@
+# Eval pilot benchmark — 10 hand-labeled queries against the Kestrel v2 corpus.
+#
+# Each item: { query, expected_chunk_ids[], notes }.
+# Chunk-ID format derived directly from ingest/chunk.ts:
+#   - Regulatory pinpoint: ${citation_id}::${paragraph_path}::p${N}
+#   - Internal / fallback: ${citation_id}::chunk_${N}
+#
+# IDs were resolved by running the chunker over corpus/*.md and matching by
+# heading_path + chunk text. See eval-pilot-plan.md / eval-plan.md for the
+# wider story.
+
+- query: "What does FINRA Rule 5310.09 require for the best-execution review of fixed income securities?"
+  expected_chunk_ids:
+    - "FINRA-Rule-5310::.09::p0"
+  notes: "Pinpoint lookup — FINRA Supplementary Material .09 (fixed-income best execution). Tests citation-aware chunker output."
+
+- query: "What pre-trade financial risk management controls does SEC Rule 15c3-5 require for broker-dealers with market access?"
+  expected_chunk_ids:
+    - "17 CFR 240.17a-3, 240.17a-4, 240.15c3-5::chunk_20"
+  notes: "Pinpoint lookup — Rule 15c3-5(c)(1) financial controls. Chunker emits chunk_20 because the (c)(1) header sits inside an already-open (c) frame, so it falls into fallback indexing within that frame."
+
+- query: "What is the Care Obligation under Regulation Best Interest (17 CFR 240.15l-1)?"
+  expected_chunk_ids:
+    - "17 CFR 240.15l-1::(a)(2)::p0"
+  notes: "Pinpoint lookup — Reg BI care obligation at (a)(2)."
+
+- query: "What does Reg SHO Rule 204 require for closing out fail-to-deliver positions?"
+  expected_chunk_ids:
+    - "17 CFR 242.200-204::(a)::p0"
+  notes: "Pinpoint lookup — Rule 204(a) close-out requirement. Note: the corpus document concatenates §§ 242.200–204 under one citation_id, so paragraph_path '(a)' appears multiple times across the doc; the close-out chunk is the one whose heading_path roots in '§ 242.204 — Close-out requirement.'"
+
+- query: "What does the Advisers Act Marketing Rule (Rule 206(4)-1) require for testimonials and endorsements?"
+  expected_chunk_ids:
+    - "17 CFR 275.206(4)-1 and 275.206(4)-2::(b)::p0"
+  notes: "Pinpoint lookup — Marketing Rule (b) testimonials and endorsements."
+
+- query: "Under Kestrel's WSP for the equities desk, who is responsible for supervising the trading desk personnel?"
+  expected_chunk_ids:
+    - "Kestrel-WSP-Equities::chunk_2"
+  notes: "Doc-level — supervisory hierarchy section of Kestrel WSP."
+
+- query: "How often does Kestrel's best-execution policy require a regular and rigorous review?"
+  expected_chunk_ids:
+    - "Kestrel-Best-Execution-Policy::chunk_4"
+    - "Kestrel-Best-Execution-Policy::chunk_5"
+  notes: "Doc-level — committee cadence (chunk_4) and review scope/quarterly cadence (chunk_5)."
+
+- query: "What were the two findings in the 2025 FINRA exam exit letter for Kestrel?"
+  expected_chunk_ids:
+    - "Kestrel-FINRA-Exam-Letter-2025::chunk_3"
+    - "Kestrel-FINRA-Exam-Letter-2025::chunk_7"
+  notes: "Doc-level — Finding 1 (Rule 5310 regular and rigorous review) and Finding 2 (Rule 3110 email supervision sampling)."
+
+- query: "What triggers Kestrel's AML program to file a Suspicious Activity Report (SAR)?"
+  expected_chunk_ids:
+    - "Kestrel-AML-Program::chunk_13"
+  notes: "Doc-level — section 5.3 SAR-SF filing criteria."
+
+- query: "What violation is described in the FINRA AWC enforcement matter for best-execution failures?"
+  expected_chunk_ids:
+    - "FINRA-AWC-2023056789201::chunk_5"
+    - "FINRA-AWC-2023056789201::chunk_6"
+  notes: "Doc-level — overview of the conduct and Rule 5310 best-execution facts."

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -1,0 +1,212 @@
+/**
+ * Eval pilot runner.
+ *
+ * Reads `eval/benchmarks/pilot.yaml`, runs each query through the compiled
+ * RAG graph (the same `graph.invoke({ query })` entry point the app uses),
+ * and computes pinpoint_precision@5 per item plus the overall mean.
+ *
+ * Output: a markdown table to stdout AND the same table written to
+ * `eval/results/<YYYY-MM-DD>-<short-sha>.md`.
+ *
+ * Exit code is always 0 — this is a pilot, no regression gating yet.
+ *
+ * Usage:
+ *   pnpm eval
+ *
+ * Required env (same as the app):
+ *   PINECONE_API_KEY, PINECONE_INDEX, OPENAI_API_KEY
+ */
+
+import "dotenv/config";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { execSync } from "child_process";
+import { resolve, join } from "path";
+import { parse as parseYaml } from "yaml";
+import { graph } from "../pipeline/graph";
+import type { Retrieval } from "../shared/types";
+
+const TOP_K = 5;
+
+interface BenchmarkItem {
+  readonly query: string;
+  readonly expected_chunk_ids: readonly string[];
+  readonly notes?: string;
+}
+
+interface ItemResult {
+  readonly query: string;
+  readonly expected: readonly string[];
+  readonly top5: readonly string[];
+  readonly hits: readonly string[];
+  readonly precision: number;
+  readonly error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function shortSha(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return "nogit";
+  }
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function loadBenchmark(path: string): BenchmarkItem[] {
+  const raw = readFileSync(path, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse YAML at ${path}: ${msg}`);
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Expected top-level array in ${path}, got ${typeof parsed}`);
+  }
+  return parsed.map((item, i): BenchmarkItem => {
+    const it = item as Partial<BenchmarkItem> | null;
+    if (!it || typeof it.query !== "string" || it.query.trim() === "") {
+      throw new Error(`Item ${i}: missing or empty 'query'`);
+    }
+    if (!Array.isArray(it.expected_chunk_ids) || it.expected_chunk_ids.length === 0) {
+      throw new Error(`Item ${i}: 'expected_chunk_ids' must be a non-empty array`);
+    }
+    return {
+      query: it.query,
+      expected_chunk_ids: it.expected_chunk_ids.map((c) => String(c)),
+      notes: typeof it.notes === "string" ? it.notes : undefined,
+    };
+  });
+}
+
+function precisionAtK(expected: readonly string[], topK: readonly string[]): {
+  hits: string[];
+  precision: number;
+} {
+  const expectedSet = new Set(expected);
+  const hits = topK.filter((id) => expectedSet.has(id));
+  return {
+    hits,
+    precision: expected.length === 0 ? 0 : hits.length / expected.length,
+  };
+}
+
+// Markdown cells must not break the table. Pipes get escaped, code fences
+// get backticked so multi-ID lists render as one cell.
+function mdCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function fmtIds(ids: readonly string[]): string {
+  if (ids.length === 0) return "_(none)_";
+  return ids.map((id) => "`" + id + "`").join("<br>");
+}
+
+function renderTable(results: readonly ItemResult[], mean: number): string {
+  const lines: string[] = [];
+  lines.push("| # | Query | Expected | Top-5 retrieved | Hit? | Precision |");
+  lines.push("|---|-------|----------|-----------------|------|-----------|");
+  results.forEach((r, i) => {
+    const hitMark = r.error
+      ? `error: ${r.error}`
+      : r.hits.length > 0
+        ? `yes (${r.hits.length}/${r.expected.length})`
+        : "no";
+    lines.push(
+      [
+        String(i + 1),
+        mdCell(r.query),
+        mdCell(fmtIds(r.expected)),
+        mdCell(fmtIds(r.top5)),
+        mdCell(hitMark),
+        r.precision.toFixed(2),
+      ].join(" | ")
+        .replace(/^/, "| ")
+        .replace(/$/, " |")
+    );
+  });
+  lines.push("");
+  lines.push(`**pinpoint_precision@${TOP_K} mean: ${mean.toFixed(3)}** across ${results.length} items.`);
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const cwd = process.cwd();
+  const benchmarkPath = resolve(cwd, "eval/benchmarks/pilot.yaml");
+  const items = loadBenchmark(benchmarkPath);
+
+  const results: ItemResult[] = [];
+
+  for (const item of items) {
+    process.stderr.write(`[eval] ${item.query.slice(0, 80)}\n`);
+    let top5: string[] = [];
+    let errorMsg: string | undefined;
+    try {
+      const state = await graph.invoke({ query: item.query });
+      const retrievals: Retrieval[] = state.retrievals ?? [];
+      top5 = retrievals.slice(0, TOP_K).map((r) => r.chunkId);
+    } catch (err) {
+      errorMsg = err instanceof Error ? err.message : String(err);
+    }
+
+    const { hits, precision } = precisionAtK(item.expected_chunk_ids, top5);
+    results.push({
+      query: item.query,
+      expected: item.expected_chunk_ids,
+      top5,
+      hits,
+      precision: errorMsg ? 0 : precision,
+      error: errorMsg,
+    });
+  }
+
+  const mean =
+    results.length === 0
+      ? 0
+      : results.reduce((s, r) => s + r.precision, 0) / results.length;
+
+  const sha = shortSha();
+  const date = todayIso();
+  const header = [
+    `# Eval pilot — ${date} @ ${sha}`,
+    "",
+    `Benchmark: \`eval/benchmarks/pilot.yaml\` (${items.length} items)`,
+    `Index: \`${process.env["PINECONE_INDEX"] ?? "(unset)"}\``,
+    "",
+  ].join("\n");
+  const table = renderTable(results, mean);
+  const fullDoc = `${header}${table}\n`;
+
+  // stdout — the human-readable report.
+  process.stdout.write(fullDoc);
+
+  // file — same content, archived under eval/results/.
+  const resultsDir = resolve(cwd, "eval/results");
+  if (!existsSync(resultsDir)) mkdirSync(resultsDir, { recursive: true });
+  const outFile = join(resultsDir, `${date}-${sha}.md`);
+  writeFileSync(outFile, fullDoc, "utf8");
+  process.stderr.write(`[eval] wrote ${outFile}\n`);
+
+  // Always exit 0 — no regression gating in the pilot.
+  process.exit(0);
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[eval] fatal: ${msg}\n`);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
     "ingest": "tsx scripts/ingest.ts",
+    "eval": "tsx eval/runner.ts",
     "test": "vitest run",
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
@@ -24,7 +25,8 @@
     "next": "16.2.3",
     "openai": "^6.0.0",
     "react": "19.2.5",
-    "react-dom": "19.2.5"
+    "react-dom": "19.2.5",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@playwright/test':
         specifier: ^1.50.0
@@ -68,7 +71,7 @@ importers:
         version: 3.8.2
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19(tsx@4.21.0)
+        version: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -77,7 +80,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0))
+        version: 4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -2702,6 +2705,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -3452,13 +3460,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -4790,13 +4798,14 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.9
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.9)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.9
       tsx: 4.21.0
+      yaml: 2.8.3
 
   postcss-nested@6.2.0(postcss@8.5.9):
     dependencies:
@@ -5134,7 +5143,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  tailwindcss@3.4.19(tsx@4.21.0):
+  tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -5153,7 +5162,7 @@ snapshots:
       postcss: 8.5.9
       postcss-import: 15.1.0(postcss@8.5.9)
       postcss-js: 4.1.0(postcss@8.5.9)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.9)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3)
       postcss-nested: 6.2.0(postcss@8.5.9)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -5308,7 +5317,7 @@ snapshots:
 
   uuid@13.0.0: {}
 
-  vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0):
+  vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -5321,11 +5330,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vitest@4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)):
+  vitest@4.1.4(@types/node@22.19.17)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -5342,7 +5352,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)
+      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -5402,6 +5412,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Closes #31

## Summary

Minimum viable eval harness. `pnpm eval` loads `eval/benchmarks/pilot.yaml`, runs each query through the same compiled graph the app uses (`pipeline/graph.ts`), computes `pinpoint_precision@5` per item plus the overall mean, and writes a markdown report to `eval/results/<date>-<sha>.md`. Always exits 0 — no regression gating yet.

See `eval-plan.md` for the wider harness roadmap; E1–E5 (#19–#23) remain open as the follow-up buildout for faithfulness, refusal, cross-doc, baselines, and CI gating.

## Changes

- `eval/benchmarks/pilot.yaml` (new) — 10 hand-labeled items covering 5 regulatory pinpoints (FINRA 5310.09, 15c3-5, Reg BI, Reg SHO 204, Marketing Rule) and 5 doc-level internal/enforcement lookups (WSP, best-ex policy, exam letter, AML SAR, AWC).
- `eval/runner.ts` (new, 212 lines) — YAML loader (try/catch, no Zod), graph-invocation loop, `pinpoint_precision@5`, markdown renderer, stdout + file output.
- `package.json` — `pnpm eval` script; `yaml` dep added.
- `.gitignore` — `eval/results/`.
- `README.md` — short Evaluation blurb.

## Reviewer verdict

`[REVIEWER AGENT] APPROVED` — all 7 acceptance criteria met; `pnpm typecheck` and `pnpm lint` pass.

Non-blocking nits flagged: header-row style inconsistency in `renderTable`, `process.cwd()` vs `import.meta.url` for benchmark path, and an operational mismatch between the spec's `kestrel-v2` index name and the live `compliance-copilot` index (runner reads from env, so not a code defect).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm eval` end-to-end against live Pinecone index returns a markdown table + mean precision and exits 0
- [ ] Rerun against the intended `kestrel-v2` index once it exists / is named consistently