### PR TITLE
Add 5 sample questions with copy-to-clipboard (temp)

### DIFF
--- a/app/Pages/DashboardPage.tsx
+++ b/app/Pages/DashboardPage.tsx
@@ -9,6 +9,8 @@ import {
 } from "../_components/shared";
 import { Card } from "../_components/card";
 import { QuestionCard } from "../_components/question-card";
+// TEMP_SAMPLE_QUESTIONS: Remove when issue #37 affordance is no longer needed.
+import { SampleQuestions } from "../_components/sample-questions";
 import { AnswerCard } from "../_components/answer-card";
 import { TraceSection } from "../_components/trace-section";
 import { CitationsPanel } from "../_components/citations-panel";
@@ -103,6 +105,9 @@ export function DashboardPage(): React.JSX.Element {
             loading={loading}
             textareaRef={textareaRef}
           />
+
+          {/* TEMP_SAMPLE_QUESTIONS: Remove when issue #37 affordance is no longer needed. */}
+          <SampleQuestions />
 
           {error && (
             <Card className="p-5 text-[13px] text-[#8b3a2f]">{error}</Card>

--- a/app/_components/sample-questions.tsx
+++ b/app/_components/sample-questions.tsx
@@ -1,0 +1,97 @@
+// TEMP_SAMPLE_QUESTIONS: Temporary dev affordance (issue #37).
+// Delete this file and its imports when no longer needed.
+// Grep for `TEMP_SAMPLE_QUESTIONS` to find all references.
+"use client";
+
+import { useState } from "react";
+import { Card } from "./card";
+
+const TEMP_SAMPLE_QUESTIONS: ReadonlyArray<{
+  regulation: string;
+  question: string;
+}> = [
+  {
+    regulation: "Reg Z",
+    question:
+      "Under Regulation Z, when must a creditor provide the initial disclosure statement for a closed-end consumer credit transaction secured by a dwelling?",
+  },
+  {
+    regulation: "Reg E",
+    question:
+      "Under Regulation E, what are the consumer's liability limits for an unauthorized electronic fund transfer reported more than two business days after discovery?",
+  },
+  {
+    regulation: "BSA/AML",
+    question:
+      "Under the Bank Secrecy Act, what are the Currency Transaction Report (CTR) filing thresholds and timing requirements for cash transactions?",
+  },
+  {
+    regulation: "Reg DD",
+    question:
+      "Under Regulation DD, what annual percentage yield (APY) disclosure is required in advertisements for deposit accounts?",
+  },
+  {
+    regulation: "UDAAP",
+    question:
+      "What are the key factors examiners consider when evaluating whether a bank's practice constitutes an unfair, deceptive, or abusive act or practice under UDAAP?",
+  },
+];
+
+export function SampleQuestions(): React.JSX.Element {
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+
+  async function handleCopy(index: number, text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedIndex(index);
+      setTimeout(() => {
+        setCopiedIndex((current) => (current === index ? null : current));
+      }, 1000);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context); no-op.
+    }
+  }
+
+  return (
+    <Card className="p-5" data-testid="sample-questions">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] uppercase tracking-[0.18em] text-[#6b7a70]">
+          Sample Questions
+        </span>
+        <span className="text-[11px] text-[#8a968f]">Click to copy</span>
+      </div>
+      <ul className="mt-3 grid gap-2">
+        {TEMP_SAMPLE_QUESTIONS.map((item, index) => {
+          const copied = copiedIndex === index;
+          return (
+            <li key={item.regulation}>
+              <button
+                type="button"
+                onClick={() => void handleCopy(index, item.question)}
+                aria-label={`Copy sample question for ${item.regulation}`}
+                className="group flex w-full items-start gap-3 rounded-xl border border-[#2d4a35]/10 bg-white/70 px-4 py-3 text-left transition-all hover:border-[#6ea580]/40 hover:bg-white focus:border-[#6ea580] focus:outline-none focus:ring-2 focus:ring-[#9cc9a9]/40"
+              >
+                <span className="mt-0.5 shrink-0 rounded-full bg-[#2d4a35]/5 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[#2d4a35]">
+                  {item.regulation}
+                </span>
+                <span className="min-w-0 flex-1 text-[13px] leading-relaxed text-[#1f2a23]">
+                  {item.question}
+                </span>
+                <span
+                  aria-live="polite"
+                  className={`ml-auto shrink-0 text-[11px] font-medium transition-opacity ${
+                    copied
+                      ? "text-[#2d4a35] opacity-100"
+                      : "text-[#8a968f] opacity-0 group-hover:opacity-100"
+                  }`}
+                >
+                  {copied ? "Copied!" : "Copy"}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </Card>
+  );
+}


### PR DESCRIPTION
Closes #37

## Summary
- New `SampleQuestions` component renders 5 compliance questions (Reg Z, Reg E, BSA/AML, Reg DD, UDAAP) below the question input on the dashboard.
- Click-to-copy via `navigator.clipboard.writeText`, with a ~1s "Copied!" indicator. Stale-index guard prevents rapid clicks from clobbering a newer indicator.
- Marked temporary via `TEMP_SAMPLE_QUESTIONS` (file header comment + constant name + two inline comments in `DashboardPage.tsx`) so it can be grepped and removed.

## Test plan
- [ ] Open `/` and confirm 5 questions appear below the question input.
- [ ] Click each and confirm clipboard contents + ~1s "Copied!" flash.
- [ ] Confirm `grep -r TEMP_SAMPLE_QUESTIONS` surfaces every touch point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)