### PR TITLE
Fix citation tooltip clipping via body portal

### DIFF
--- a/app/_components/citation-chip.tsx
+++ b/app/_components/citation-chip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { TooltipPortal } from "./tooltip-portal";
 
 export function CitationChip({
   n,
@@ -11,16 +12,23 @@ export function CitationChip({
   excerpt?: string;
   onActivate?: (n: number) => void;
 }): React.JSX.Element {
-  const [hovered, setHovered] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const [rect, setRect] = useState<DOMRect | null>(null);
   const text = excerpt ? truncate(excerpt, 400) : null;
+
+  const handleEnter = (): void => {
+    if (buttonRef.current) setRect(buttonRef.current.getBoundingClientRect());
+  };
+  const handleLeave = (): void => setRect(null);
 
   return (
     <span
       className="relative inline-flex"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
     >
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => onActivate?.(n)}
         aria-label={`Open citation ${n}`}
@@ -28,20 +36,26 @@ export function CitationChip({
       >
         {n}
       </button>
-      {hovered && text && (
-        <span
-          role="tooltip"
-          className="tooltip-in pointer-events-none absolute bottom-full left-1/2 z-30 w-[320px] -translate-x-1/2 -translate-y-2 rounded-xl bg-[#1f2a23] px-3.5 py-2.5 text-[12px] leading-relaxed text-white/95 shadow-[0_12px_32px_-8px_rgba(31,42,35,0.4)]"
-        >
-          <span className="mb-1 block text-[9px] uppercase tracking-[0.18em] text-white/55">
-            Citation {n}
-          </span>
-          {text}
+      {rect && text && (
+        <TooltipPortal>
           <span
-            aria-hidden
-            className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-[#1f2a23]"
-          />
-        </span>
+            role="tooltip"
+            className="tooltip-in pointer-events-none fixed z-[1000] w-[320px] rounded-xl bg-[#1f2a23] px-3.5 py-2.5 text-[12px] leading-relaxed text-white/95 shadow-[0_12px_32px_-8px_rgba(31,42,35,0.4)]"
+            style={{
+              left: rect.left + rect.width / 2,
+              top: rect.top,
+            }}
+          >
+            <span className="mb-1 block text-[9px] uppercase tracking-[0.18em] text-white/55">
+              Citation {n}
+            </span>
+            {text}
+            <span
+              aria-hidden
+              className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-[#1f2a23]"
+            />
+          </span>
+        </TooltipPortal>
       )}
     </span>
   );

--- a/app/_components/tooltip-portal.tsx
+++ b/app/_components/tooltip-portal.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
+
+// Empty subscribe — the hook is only used to return different values
+// between server render ("not hydrated") and client render ("hydrated").
+const subscribe = (): (() => void) => () => {};
+const getClientSnapshot = (): boolean => true;
+const getServerSnapshot = (): boolean => false;
+
+/**
+ * Renders children into `document.body` via a React portal.
+ *
+ * Escapes ancestor `overflow: hidden`, `overflow: clip`, and `contain`
+ * rules that would otherwise clip a positioned tooltip. Renders nothing
+ * during SSR and the initial hydration pass; only mounts the portal on
+ * the client.
+ */
+export function TooltipPortal({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element | null {
+  const isClient = useSyncExternalStore(
+    subscribe,
+    getClientSnapshot,
+    getServerSnapshot,
+  );
+
+  if (!isClient || typeof document === "undefined") return null;
+  return createPortal(children, document.body);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,11 +24,11 @@
 @keyframes tooltipIn {
   0% {
     opacity: 0;
-    transform: translate(-50%, -2px) scale(0.96);
+    transform: translate(-50%, calc(-100% - 2px)) scale(0.96);
   }
   100% {
     opacity: 1;
-    transform: translate(-50%, -8px) scale(1);
+    transform: translate(-50%, calc(-100% - 8px)) scale(1);
   }
 }
 


### PR DESCRIPTION
Closes #38

## Summary
- Tooltip now renders through a new `TooltipPortal` (`createPortal` to `document.body`), escaping the `overflow-hidden` on the answer card wrapper that was clipping it.
- Positioning uses `position: fixed` with `getBoundingClientRect()` + an updated `.tooltip-in` keyframe (`translate(-50%, calc(-100% - 8px))`) so the tooltip sits centered above the chip.
- SSR-safe via `useSyncExternalStore` + `typeof document` guard; `rect` populates only on mouse-enter so the portal branch never renders during SSR.
- Click-to-open-citations behavior on the chip is untouched.

## Test plan
- [ ] Hover citation chips near all 4 edges of the answer card — tooltip renders fully, no clipping.
- [ ] Tooltip layers above the citations panel and adjacent cards.
- [ ] Click a chip — citations panel still opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)