### PR TITLE
Citation card: truncate excerpt with show more toggle

### DIFF
--- a/app/_components/citation-card.tsx
+++ b/app/_components/citation-card.tsx
@@ -1,5 +1,6 @@
 import type { Citation, Retrieval } from "../../shared/types";
 import { Card } from "./card";
+import { CitationExcerpt } from "./citation-excerpt";
 import { authorityStyle, citationMarkerNumber } from "./shared";
 
 export function CitationCard({
@@ -18,11 +19,7 @@ export function CitationCard({
   const score = retrieval?.score;
   const version = retrieval?.metadata?.versionStatus;
   const date = retrieval?.metadata?.effectiveDate;
-  const excerptSrc = retrieval?.text ?? "";
-  const excerpt =
-    excerptSrc.length > 240
-      ? `${excerptSrc.slice(0, 240).trimEnd()}…`
-      : excerptSrc;
+  const excerpt = retrieval?.text ?? "";
   const sourceUrl = retrieval?.metadata?.sourceUrl;
 
   return (
@@ -64,11 +61,7 @@ export function CitationCard({
             {date && <span>Effective {date}</span>}
           </div>
         )}
-        {excerpt && (
-          <p className="mt-3 text-[12.5px] leading-relaxed text-[#3a4540]">
-            &ldquo;{excerpt}&rdquo;
-          </p>
-        )}
+        {excerpt && <CitationExcerpt text={excerpt} />}
         {sourceUrl && (
           <a
             href={sourceUrl}

--- a/app/_components/citation-excerpt.tsx
+++ b/app/_components/citation-excerpt.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export function CitationExcerpt({
+  text,
+}: {
+  text: string;
+}): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const paraRef = useRef<HTMLParagraphElement | null>(null);
+
+  // Detect whether the excerpt actually overflows three lines at the
+  // current card width. We measure only in the collapsed state — that's
+  // when line-clamp-3 is active and scrollHeight exceeds clientHeight if
+  // the content is truncated. Once we know the content overflows, the
+  // "Show less" button must remain visible while expanded.
+  useEffect(() => {
+    if (expanded) return;
+    const el = paraRef.current;
+    if (!el) return;
+
+    function measure(): void {
+      if (!el) return;
+      setIsTruncated(el.scrollHeight - el.clientHeight > 1);
+    }
+
+    measure();
+
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => measure());
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [text, expanded]);
+
+  return (
+    <div className="mt-3">
+      {/* line-clamp-3 when collapsed preserves any inline markup (e.g.
+          match highlights) because it clamps at the CSS layer rather
+          than truncating the source string. */}
+      <p
+        ref={paraRef}
+        className={`text-[12.5px] leading-relaxed text-[#3a4540] ${
+          expanded ? "" : "line-clamp-3"
+        }`}
+      >
+        &ldquo;{text}&rdquo;
+      </p>
+      {isTruncated && (
+        <button
+          type="button"
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-expanded={expanded}
+          className="mt-1.5 inline-flex items-center text-[11.5px] font-medium text-[#2d4a35] transition-colors hover:text-[#6ea580]"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #39

## Summary
- New `CitationExcerpt` component wraps the citation body text with a `line-clamp-3` clamp, a local `useState` for expanded/collapsed, and a `ResizeObserver`-backed measurement that sets `isTruncated` from `scrollHeight - clientHeight > 1`.
- "Show more" / "Show less" button renders only when content is actually truncated; expansion is per-card.
- Uses CSS-level clamp rather than string slicing, so future inline highlight/match markup is preserved.
- No citation data-shape changes; `citations-panel.tsx` untouched.

## Test plan
- [ ] Render a query with 5+ citations — each card clamps to 3 lines with "Show more".
- [ ] Expand one card — siblings remain collapsed.
- [ ] Short citations (fewer than 3 lines) show no "Show more" button.
- [ ] Resize the viewport — button appears/disappears correctly as clamp state changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)