### PR TITLE
Implement /evaluations dashboard (retrieval + answer metrics, live runner)

### DIFF
--- a/app/Pages/EvaluationsPage.tsx
+++ b/app/Pages/EvaluationsPage.tsx
@@ -1,4 +1,5 @@
-import { Card } from "../_components/card";
+import { AnswerEvaluation } from "../_components/answer-evaluation";
+import { RetrievalEvaluation } from "../_components/retrieval-evaluation";
 import { SERIF } from "../_components/shared";
 
 export function EvaluationsPage(): React.JSX.Element {
@@ -15,11 +16,10 @@ export function EvaluationsPage(): React.JSX.Element {
           Track answer quality across regression suites and ad-hoc probes.
         </p>
       </div>
-      <Card className="p-8">
-        <p className="text-[13px] text-[#6b7a70]">
-          Evaluations dashboard coming soon.
-        </p>
-      </Card>
+      <div className="space-y-8">
+        <RetrievalEvaluation />
+        <AnswerEvaluation />
+      </div>
     </main>
   );
 }

--- a/app/_components/answer-evaluation.tsx
+++ b/app/_components/answer-evaluation.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { CategoryBarChart } from "./category-bar-chart";
+import { EvaluationSection } from "./evaluation-section";
+import { MetricCard } from "./metric-card";
+import {
+  tierForJudge,
+  type AnswerStreamItem,
+  type AnswerSummary,
+} from "./evaluation-types";
+import { streamNdjson } from "./ndjson-stream";
+
+/**
+ * Answer-evaluation section. Triggers POST /api/evaluations/answer, streams
+ * per-item judge scores for the progress indicator, and renders accuracy /
+ * completeness / relevance cards plus a category bar chart when complete.
+ */
+export function AnswerEvaluation(): React.JSX.Element {
+  const [running, setRunning] = useState(false);
+  const [progress, setProgress] = useState<{
+    index: number;
+    total: number;
+  } | null>(null);
+  const [summary, setSummary] = useState<AnswerSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleRun() {
+    if (running) return;
+    setRunning(true);
+    setError(null);
+    setSummary(null);
+    setProgress(null);
+
+    try {
+      await streamNdjson("/api/evaluations/answer", (obj) => {
+        const record = obj as Record<string, unknown>;
+        if (record["error"] && !record["done"] && !("index" in record)) {
+          setError(String(record["error"]));
+          return;
+        }
+        if (record["done"]) {
+          setSummary(record["summary"] as AnswerSummary);
+          return;
+        }
+        const item = record as unknown as AnswerStreamItem;
+        if (typeof item.index === "number" && typeof item.total === "number") {
+          setProgress({ index: item.index, total: item.total });
+        }
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Evaluation failed.");
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  const hasResults = summary !== null;
+
+  return (
+    <EvaluationSection
+      title="Answer evaluation"
+      description="Runs the benchmark through the full pipeline and uses an LLM-as-judge to score accuracy, completeness and relevance on a 1–5 scale."
+      running={running}
+      progress={progress}
+      hasResults={hasResults}
+      error={error}
+      onRun={() => void handleRun()}
+    >
+      {summary && (
+        <>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <MetricCard
+              label="Accuracy"
+              value={summary.accuracy}
+              tier={tierForJudge(summary.accuracy)}
+              format="judge"
+              hint={`Across ${summary.total} items`}
+            />
+            <MetricCard
+              label="Completeness"
+              value={summary.completeness}
+              tier={tierForJudge(summary.completeness)}
+              format="judge"
+            />
+            <MetricCard
+              label="Relevance"
+              value={summary.relevance}
+              tier={tierForJudge(summary.relevance)}
+              format="judge"
+            />
+          </div>
+          <CategoryBarChart
+            title="Average accuracy by category"
+            scale="1-5"
+            format="judge"
+            tierFor="judge"
+            rows={summary.categories.map((c) => ({
+              category: c.category,
+              value: c.avgAccuracy,
+              count: c.count,
+            }))}
+          />
+        </>
+      )}
+    </EvaluationSection>
+  );
+}

--- a/app/_components/category-bar-chart.tsx
+++ b/app/_components/category-bar-chart.tsx
@@ -1,0 +1,108 @@
+import { Card } from "./card";
+import {
+  formatMetric,
+  paletteForTier,
+  tierForJudge,
+  tierForRatio,
+  type MetricFormat,
+  type ThresholdTier,
+} from "./evaluation-types";
+
+export interface CategoryBarRow {
+  readonly category: string;
+  readonly value: number;
+  readonly count: number;
+}
+
+/**
+ * Native HTML/CSS horizontal bar chart for average-by-category views. No
+ * dependency on any chart library — bar widths are CSS percentages.
+ */
+export function CategoryBarChart({
+  title,
+  rows,
+  scale,
+  format,
+  tierFor,
+}: {
+  title: string;
+  rows: readonly CategoryBarRow[];
+  scale: "0-1" | "1-5";
+  format: MetricFormat;
+  tierFor: "ratio" | "judge";
+}): React.JSX.Element {
+  return (
+    <Card className="p-5">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-[13px] font-medium tracking-tight text-[#1f2a23]">
+          {title}
+        </h3>
+        <span className="text-[11px] text-[#8a968f]">
+          scale {scale === "0-1" ? "0 – 1" : "1 – 5"}
+        </span>
+      </div>
+      <ul className="mt-4 space-y-2.5">
+        {rows.length === 0 && (
+          <li className="text-[12px] text-[#8a968f]">No categories yet.</li>
+        )}
+        {rows.map((row) => (
+          <Bar
+            key={row.category}
+            row={row}
+            scale={scale}
+            format={format}
+            tierFor={tierFor}
+          />
+        ))}
+      </ul>
+    </Card>
+  );
+}
+
+// Private helper — kept in this file per agents.md "small private helper"
+// allowance. Not exported.
+function Bar({
+  row,
+  scale,
+  format,
+  tierFor,
+}: {
+  row: CategoryBarRow;
+  scale: "0-1" | "1-5";
+  format: MetricFormat;
+  tierFor: "ratio" | "judge";
+}): React.JSX.Element {
+  const domainMax = scale === "0-1" ? 1 : 5;
+  const domainMin = scale === "0-1" ? 0 : 1;
+  const clamped = Math.max(domainMin, Math.min(domainMax, row.value));
+  const pctRaw = (clamped - domainMin) / (domainMax - domainMin);
+  // Ensure a visible sliver for very low non-zero scores and keep zero zero.
+  const widthPct = row.value <= domainMin ? 0 : Math.max(pctRaw * 100, 2);
+  const tier: ThresholdTier =
+    tierFor === "ratio" ? tierForRatio(row.value) : tierForJudge(row.value);
+  const palette = paletteForTier(tier);
+
+  return (
+    <li>
+      <div className="flex items-center justify-between text-[11px] text-[#6b7a70]">
+        <span className="truncate pr-3">
+          {row.category}
+          <span className="ml-2 text-[#a0a9a4]">n={row.count}</span>
+        </span>
+      </div>
+      <div className="mt-1 flex items-center gap-3">
+        <div className="relative h-2.5 flex-1 overflow-hidden rounded-full bg-[#eef1ee]">
+          <div
+            className={`h-full ${palette.bar}`}
+            style={{ width: `${widthPct}%` }}
+          />
+        </div>
+        <span
+          className={`w-16 shrink-0 text-right text-[12px] tabular-nums ${palette.value}`}
+        >
+          {formatMetric(row.value, format)}
+        </span>
+      </div>
+    </li>
+  );
+}

--- a/app/_components/evaluation-section.tsx
+++ b/app/_components/evaluation-section.tsx
@@ -1,0 +1,69 @@
+import { Card } from "./card";
+import { RunEvaluationButton } from "./run-evaluation-button";
+import { SERIF } from "./shared";
+
+/**
+ * Generic /evaluations section wrapper: title, description, run-button, and
+ * a slot for the pre-run hint or the rendered results. Matches the two-card
+ * stacked layout from the Gradio prototype but styled with the app theme
+ * (muted greens/creams, Card, SERIF title).
+ */
+export function EvaluationSection({
+  title,
+  description,
+  running,
+  progress,
+  hasResults,
+  error,
+  onRun,
+  children,
+}: {
+  title: string;
+  description: string;
+  running: boolean;
+  progress: { index: number; total: number } | null;
+  hasResults: boolean;
+  error: string | null;
+  onRun: () => void;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <section className="space-y-4">
+      <Card className="p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h2
+              className="text-[20px] tracking-tight text-[#1f2a23]"
+              style={SERIF}
+            >
+              {title}
+            </h2>
+            <p className="mt-1 max-w-[52ch] text-[13px] text-[#6b7a70]">
+              {description}
+            </p>
+          </div>
+          <RunEvaluationButton
+            onClick={onRun}
+            running={running}
+            progress={progress}
+          />
+        </div>
+        {error && (
+          <div className="mt-4 rounded-xl border border-[#c5a0a5]/40 bg-[#efdfe2]/40 px-4 py-2.5 text-[12px] text-[#8b3a2f]">
+            {error}
+          </div>
+        )}
+      </Card>
+
+      {hasResults ? (
+        <div className="space-y-4">{children}</div>
+      ) : (
+        <Card className="p-6">
+          <p className="text-[13px] text-[#8a968f]">
+            Click &ldquo;Run evaluation&rdquo; to start.
+          </p>
+        </Card>
+      )}
+    </section>
+  );
+}

--- a/app/_components/evaluation-types.ts
+++ b/app/_components/evaluation-types.ts
@@ -1,0 +1,118 @@
+/**
+ * Types shared between the streaming evaluation API routes and the
+ * /evaluations dashboard UI. Backed by `eval/core.ts` scoring.
+ */
+
+export type ThresholdTier = "green" | "amber" | "red";
+
+export interface RetrievalCategorySummary {
+  readonly category: string;
+  readonly avgMrr: number;
+  readonly count: number;
+}
+
+export interface RetrievalSummary {
+  readonly total: number;
+  readonly mrr: number;
+  readonly ndcg: number;
+  readonly keywordCoverage: number;
+  readonly pinpointPrecision: number;
+  readonly categories: readonly RetrievalCategorySummary[];
+}
+
+export interface RetrievalStreamItem {
+  readonly index: number;
+  readonly total: number;
+  readonly query: string;
+  readonly category: string;
+  readonly pinpointPrecision: number;
+  readonly mrr: number;
+  readonly ndcg: number;
+  readonly keywordCoverage: number;
+}
+
+export interface AnswerCategorySummary {
+  readonly category: string;
+  readonly avgAccuracy: number;
+  readonly count: number;
+}
+
+export interface AnswerSummary {
+  readonly total: number;
+  readonly accuracy: number;
+  readonly completeness: number;
+  readonly relevance: number;
+  readonly categories: readonly AnswerCategorySummary[];
+}
+
+export interface AnswerStreamItem {
+  readonly index: number;
+  readonly total: number;
+  readonly query: string;
+  readonly category: string;
+  readonly accuracy?: number;
+  readonly completeness?: number;
+  readonly relevance?: number;
+  readonly feedback?: string;
+  readonly error?: string;
+}
+
+// ── threshold tiers (match the Gradio prototype) ────────────────────────────
+
+export function tierForRatio(value: number, green = 0.9, amber = 0.75): ThresholdTier {
+  if (value >= green) return "green";
+  if (value >= amber) return "amber";
+  return "red";
+}
+
+export function tierForJudge(value: number): ThresholdTier {
+  if (value >= 4.5) return "green";
+  if (value >= 4.0) return "amber";
+  return "red";
+}
+
+// ── tier → colour tokens (match spec palette exactly) ───────────────────────
+
+export interface TierPalette {
+  readonly strip: string;
+  readonly value: string;
+  readonly bar: string;
+}
+
+export function paletteForTier(tier: ThresholdTier): TierPalette {
+  switch (tier) {
+    case "green":
+      return {
+        strip: "bg-[#9cc9a9]",
+        value: "text-[#2d4a35]",
+        bar: "bg-[#9cc9a9]",
+      };
+    case "amber":
+      return {
+        strip: "bg-[#fab89a]",
+        value: "text-[#8b4a2f]",
+        bar: "bg-[#fab89a]",
+      };
+    case "red":
+      return {
+        strip: "bg-[#c5a0a5]",
+        value: "text-[#8b3a2f]",
+        bar: "bg-[#c5a0a5]",
+      };
+  }
+}
+
+// ── value formatting ────────────────────────────────────────────────────────
+
+export type MetricFormat = "ratio" | "percent" | "judge";
+
+export function formatMetric(value: number, format: MetricFormat): string {
+  switch (format) {
+    case "ratio":
+      return value.toFixed(3);
+    case "percent":
+      return `${Math.round(value * 100)}%`;
+    case "judge":
+      return `${value.toFixed(2)}/5`;
+  }
+}

--- a/app/_components/metric-card.tsx
+++ b/app/_components/metric-card.tsx
@@ -1,0 +1,47 @@
+import { Card } from "./card";
+import {
+  formatMetric,
+  paletteForTier,
+  type MetricFormat,
+  type ThresholdTier,
+} from "./evaluation-types";
+
+/**
+ * Large metric card used in the /evaluations dashboard. Each card shows a
+ * small label, a big numeric value (formatted per the metric type) and a
+ * soft coloured left strip reflecting the green/amber/red threshold tier.
+ */
+export function MetricCard({
+  label,
+  value,
+  tier,
+  format,
+  hint,
+}: {
+  label: string;
+  value: number;
+  tier: ThresholdTier;
+  format: MetricFormat;
+  hint?: string;
+}): React.JSX.Element {
+  const palette = paletteForTier(tier);
+  return (
+    <Card className="relative overflow-hidden p-5">
+      <div
+        aria-hidden
+        className={`absolute left-0 top-0 h-full w-1.5 ${palette.strip}`}
+      />
+      <div className="pl-3">
+        <div className="text-[11px] uppercase tracking-[0.18em] text-[#6b7a70]">
+          {label}
+        </div>
+        <div className={`mt-2 text-[32px] font-light leading-none ${palette.value}`}>
+          {formatMetric(value, format)}
+        </div>
+        {hint && (
+          <div className="mt-2 text-[11px] text-[#8a968f]">{hint}</div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/app/_components/ndjson-stream.ts
+++ b/app/_components/ndjson-stream.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimal NDJSON stream reader. POSTs to `url`, reads the response body as a
+ * stream, and calls `onLine` for each parsed JSON object as it arrives.
+ * Returns once the server closes the stream. Throws on HTTP errors or if
+ * the stream is aborted via the supplied signal.
+ */
+export async function streamNdjson(
+  url: string,
+  onLine: (obj: unknown) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+    signal,
+  });
+  if (!res.ok) {
+    let message = `Request failed: ${res.status}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      // non-JSON body — keep the default message.
+    }
+    throw new Error(message);
+  }
+  if (!res.body) throw new Error("No response body");
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    // NDJSON: split on newline, keep the trailing partial line in buffer.
+    let nl = buffer.indexOf("\n");
+    while (nl !== -1) {
+      const line = buffer.slice(0, nl).trim();
+      buffer = buffer.slice(nl + 1);
+      if (line.length > 0) {
+        try {
+          onLine(JSON.parse(line));
+        } catch {
+          // Skip malformed lines — server shouldn't emit them, but we'd
+          // rather drop one item than abort the whole stream.
+        }
+      }
+      nl = buffer.indexOf("\n");
+    }
+  }
+
+  // Flush any final partial (unterminated) line.
+  const tail = buffer.trim();
+  if (tail.length > 0) {
+    try {
+      onLine(JSON.parse(tail));
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/app/_components/retrieval-evaluation.tsx
+++ b/app/_components/retrieval-evaluation.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { CategoryBarChart } from "./category-bar-chart";
+import { EvaluationSection } from "./evaluation-section";
+import { MetricCard } from "./metric-card";
+import {
+  tierForRatio,
+  type RetrievalStreamItem,
+  type RetrievalSummary,
+} from "./evaluation-types";
+import { streamNdjson } from "./ndjson-stream";
+
+/**
+ * Retrieval-evaluation section. Triggers POST /api/evaluations/retrieval,
+ * streams per-item results to update the progress indicator, and renders
+ * three metric cards + a bar chart of average MRR by category when done.
+ */
+export function RetrievalEvaluation(): React.JSX.Element {
+  const [running, setRunning] = useState(false);
+  const [progress, setProgress] = useState<{
+    index: number;
+    total: number;
+  } | null>(null);
+  const [summary, setSummary] = useState<RetrievalSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleRun() {
+    if (running) return;
+    setRunning(true);
+    setError(null);
+    setSummary(null);
+    setProgress(null);
+
+    try {
+      await streamNdjson("/api/evaluations/retrieval", (obj) => {
+        const record = obj as Record<string, unknown>;
+        if (record["error"] && !record["done"]) {
+          setError(String(record["error"]));
+          return;
+        }
+        if (record["done"]) {
+          setSummary(record["summary"] as RetrievalSummary);
+          return;
+        }
+        const item = record as unknown as RetrievalStreamItem;
+        if (typeof item.index === "number" && typeof item.total === "number") {
+          setProgress({ index: item.index, total: item.total });
+        }
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Evaluation failed.");
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  const hasResults = summary !== null;
+
+  return (
+    <EvaluationSection
+      title="Retrieval evaluation"
+      description="Runs the benchmark through production retrieval and scores MRR, nDCG and keyword coverage. Thresholds match the eval prototype."
+      running={running}
+      progress={progress}
+      hasResults={hasResults}
+      error={error}
+      onRun={() => void handleRun()}
+    >
+      {summary && (
+        <>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <MetricCard
+              label="MRR"
+              value={summary.mrr}
+              tier={tierForRatio(summary.mrr)}
+              format="ratio"
+              hint={`Across ${summary.total} items`}
+            />
+            <MetricCard
+              label="nDCG"
+              value={summary.ndcg}
+              tier={tierForRatio(summary.ndcg)}
+              format="ratio"
+            />
+            <MetricCard
+              label="Keyword coverage"
+              value={summary.keywordCoverage}
+              tier={tierForRatio(summary.keywordCoverage)}
+              format="percent"
+            />
+          </div>
+          <CategoryBarChart
+            title="Average MRR by category"
+            scale="0-1"
+            format="ratio"
+            tierFor="ratio"
+            rows={summary.categories.map((c) => ({
+              category: c.category,
+              value: c.avgMrr,
+              count: c.count,
+            }))}
+          />
+        </>
+      )}
+    </EvaluationSection>
+  );
+}

--- a/app/_components/run-evaluation-button.tsx
+++ b/app/_components/run-evaluation-button.tsx
@@ -1,0 +1,72 @@
+/**
+ * "Run evaluation" button used on the /evaluations dashboard. Shows a
+ * disabled loading state and a small progress indicator ("Evaluating test
+ * N/M…") while items stream back from the server.
+ */
+export function RunEvaluationButton({
+  onClick,
+  running,
+  progress,
+  idleLabel = "Run evaluation",
+}: {
+  onClick: () => void;
+  running: boolean;
+  progress: { index: number; total: number } | null;
+  idleLabel?: string;
+}): React.JSX.Element {
+  const busy = running;
+  const progressText =
+    progress && progress.total > 0
+      ? `Evaluating test ${progress.index}/${progress.total}…`
+      : "Starting…";
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={busy}
+        aria-busy={busy}
+        aria-label={busy ? progressText : idleLabel}
+        className="group relative inline-flex items-center gap-2 overflow-hidden rounded-xl bg-[#2d4a35] px-5 py-2.5 text-[13px] font-medium text-white shadow-[0_2px_8px_-2px_rgba(45,74,53,0.35)] transition-all hover:bg-[#1f3526] hover:shadow-[0_4px_14px_-2px_rgba(45,74,53,0.45)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-[#2d4a35]"
+      >
+        {busy ? <Spinner /> : null}
+        <span>{busy ? "Evaluating…" : idleLabel}</span>
+      </button>
+      {busy && (
+        <span
+          className="text-[12px] text-[#6b7a70]"
+          aria-live="polite"
+          role="status"
+        >
+          {progressText}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function Spinner(): React.JSX.Element {
+  return (
+    <svg
+      className="h-3.5 w-3.5 animate-spin"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden
+    >
+      <circle
+        cx="8"
+        cy="8"
+        r="6.5"
+        stroke="currentColor"
+        strokeOpacity="0.3"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M14.5 8a6.5 6.5 0 0 0-6.5-6.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/app/api/evaluations/answer/route.ts
+++ b/app/api/evaluations/answer/route.ts
@@ -1,0 +1,145 @@
+import { NextResponse } from "next/server";
+import { resolve } from "path";
+import { graph } from "../../../../pipeline/graph";
+import {
+  createOpenAI,
+  judgeAnswer,
+  loadBenchmark,
+} from "../../../../eval/core";
+
+export const runtime = "nodejs";
+// Judge is a model call per item × 30 items — leave a 5-minute budget and
+// rely on NDJSON streaming to keep the connection warm.
+export const maxDuration = 300;
+
+/**
+ * Streams NDJSON results for answer (LLM-as-judge) evaluation.
+ *
+ * Each completed benchmark item is streamed as one JSON line:
+ *   { index, total, query, category, accuracy, completeness, relevance,
+ *     feedback }
+ *
+ * A final line with { done: true, summary: {...} } is emitted once all items
+ * finish. Items where the judge throws are streamed with { error } instead of
+ * scores so the UI can still show progress.
+ */
+export async function POST(): Promise<Response> {
+  let items;
+  let openai;
+  try {
+    const benchmarkPath = resolve(
+      process.cwd(),
+      "eval/benchmarks/pilot.yaml",
+    );
+    items = loadBenchmark(benchmarkPath);
+    openai = createOpenAI();
+  } catch (err) {
+    console.error("[api/evaluations/answer] setup error:", err);
+    return NextResponse.json(
+      { error: "Failed to initialise evaluation" },
+      { status: 500 },
+    );
+  }
+
+  const encoder = new TextEncoder();
+  const total = items.length;
+  const loadedItems = items;
+  const client = openai;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const write = (obj: unknown) => {
+        controller.enqueue(encoder.encode(JSON.stringify(obj) + "\n"));
+      };
+
+      const perItem: Array<{
+        category: string;
+        accuracy: number;
+        completeness: number;
+        relevance: number;
+      }> = [];
+
+      try {
+        for (let i = 0; i < loadedItems.length; i++) {
+          const item = loadedItems[i];
+
+          // Production answer via compiled graph
+          const state = await graph.invoke({ query: item.query });
+          const answer = state.answer ?? "";
+
+          try {
+            const judge = await judgeAnswer(client, item, answer);
+            perItem.push({
+              category: item.category,
+              accuracy: judge.accuracy,
+              completeness: judge.completeness,
+              relevance: judge.relevance,
+            });
+            write({
+              index: i + 1,
+              total,
+              query: item.query,
+              category: item.category,
+              accuracy: judge.accuracy,
+              completeness: judge.completeness,
+              relevance: judge.relevance,
+              feedback: judge.feedback,
+            });
+          } catch (err) {
+            write({
+              index: i + 1,
+              total,
+              query: item.query,
+              category: item.category,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
+        const avg = (xs: number[]) =>
+          xs.length === 0 ? 0 : xs.reduce((s, x) => s + x, 0) / xs.length;
+        const accAvg = avg(perItem.map((p) => p.accuracy));
+        const compAvg = avg(perItem.map((p) => p.completeness));
+        const relAvg = avg(perItem.map((p) => p.relevance));
+
+        const byCategory = new Map<string, number[]>();
+        for (const p of perItem) {
+          const arr = byCategory.get(p.category) ?? [];
+          arr.push(p.accuracy);
+          byCategory.set(p.category, arr);
+        }
+        const categories = Array.from(byCategory.entries()).map(
+          ([category, accs]) => ({
+            category,
+            avgAccuracy: avg(accs),
+            count: accs.length,
+          }),
+        );
+
+        write({
+          done: true,
+          summary: {
+            total,
+            accuracy: accAvg,
+            completeness: compAvg,
+            relevance: relAvg,
+            categories,
+          },
+        });
+      } catch (err) {
+        console.error("[api/evaluations/answer] error:", err);
+        write({ error: err instanceof Error ? err.message : String(err) });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/x-ndjson; charset=utf-8",
+      "Cache-Control": "no-store, no-transform",
+    },
+  });
+}

--- a/app/api/evaluations/retrieval/route.ts
+++ b/app/api/evaluations/retrieval/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from "next/server";
+import { resolve } from "path";
+import { graph } from "../../../../pipeline/graph";
+import {
+  RETRIEVAL_K,
+  createPineconeIndex,
+  loadBenchmark,
+  retrieveForEval,
+  scoreKeywordMetrics,
+  scorePinpoint,
+} from "../../../../eval/core";
+
+export const runtime = "nodejs";
+// Streaming responses need a generous budget; 5 min matches the answer eval.
+export const maxDuration = 300;
+
+/**
+ * Streams NDJSON results for retrieval evaluation.
+ *
+ * Each completed benchmark item is streamed as one JSON line:
+ *   { index, total, query, category, pinpointPrecision, mrr, ndcg,
+ *     keywordCoverage }
+ *
+ * A final line with { done: true, summary: {...} } is emitted once all items
+ * finish. Client parses lines with response.body.getReader() as they arrive.
+ */
+export async function POST(): Promise<Response> {
+  let items;
+  let pineconeIndex;
+  try {
+    const benchmarkPath = resolve(
+      process.cwd(),
+      "eval/benchmarks/pilot.yaml",
+    );
+    items = loadBenchmark(benchmarkPath);
+    pineconeIndex = createPineconeIndex();
+  } catch (err) {
+    console.error("[api/evaluations/retrieval] setup error:", err);
+    return NextResponse.json(
+      { error: "Failed to initialise evaluation" },
+      { status: 500 },
+    );
+  }
+
+  const encoder = new TextEncoder();
+  const total = items.length;
+  const loadedItems = items;
+  const index = pineconeIndex;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const write = (obj: unknown) => {
+        controller.enqueue(encoder.encode(JSON.stringify(obj) + "\n"));
+      };
+
+      const perItem: Array<{
+        category: string;
+        mrr: number;
+        ndcg: number;
+        keywordCoverage: number;
+        pinpointPrecision: number;
+      }> = [];
+
+      try {
+        for (let i = 0; i < loadedItems.length; i++) {
+          const item = loadedItems[i];
+
+          // Production retrieval via compiled graph (top-5)
+          const state = await graph.invoke({ query: item.query });
+          const topFiveIds = (state.retrievals ?? []).map((r) => r.chunkId);
+          const { pinpointPrecision } = scorePinpoint(
+            topFiveIds,
+            item.expected_chunk_ids,
+          );
+
+          // Separate top-K for keyword-based retrieval metrics
+          const topK = await retrieveForEval(index, item.query, RETRIEVAL_K);
+          const { mrr, ndcg, keywordCoverage } = scoreKeywordMetrics(
+            item.keywords,
+            topK,
+            RETRIEVAL_K,
+          );
+
+          perItem.push({
+            category: item.category,
+            mrr,
+            ndcg,
+            keywordCoverage,
+            pinpointPrecision,
+          });
+
+          write({
+            index: i + 1,
+            total,
+            query: item.query,
+            category: item.category,
+            pinpointPrecision,
+            mrr,
+            ndcg,
+            keywordCoverage,
+          });
+        }
+
+        const avg = (xs: number[]) =>
+          xs.length === 0 ? 0 : xs.reduce((s, x) => s + x, 0) / xs.length;
+        const mrrAvg = avg(perItem.map((p) => p.mrr));
+        const ndcgAvg = avg(perItem.map((p) => p.ndcg));
+        const covAvg = avg(perItem.map((p) => p.keywordCoverage));
+        const pinAvg = avg(perItem.map((p) => p.pinpointPrecision));
+
+        const byCategory = new Map<string, number[]>();
+        for (const p of perItem) {
+          const arr = byCategory.get(p.category) ?? [];
+          arr.push(p.mrr);
+          byCategory.set(p.category, arr);
+        }
+        const categories = Array.from(byCategory.entries()).map(
+          ([category, mrrs]) => ({
+            category,
+            avgMrr: avg(mrrs),
+            count: mrrs.length,
+          }),
+        );
+
+        write({
+          done: true,
+          summary: {
+            total,
+            mrr: mrrAvg,
+            ndcg: ndcgAvg,
+            keywordCoverage: covAvg,
+            pinpointPrecision: pinAvg,
+            categories,
+          },
+        });
+      } catch (err) {
+        console.error("[api/evaluations/retrieval] error:", err);
+        write({
+          error: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/x-ndjson; charset=utf-8",
+      "Cache-Control": "no-store, no-transform",
+    },
+  });
+}

--- a/eval/core.ts
+++ b/eval/core.ts
@@ -1,0 +1,261 @@
+/**
+ * Shared eval core.
+ *
+ * Pure scoring logic extracted from `eval/runner.ts`, reusable by both the
+ * CLI runner and the streaming API routes under `app/api/evaluations/`.
+ * Adding a new consumer should not duplicate any of the scoring below.
+ *
+ * Env at runtime: PINECONE_API_KEY, PINECONE_INDEX, OPENAI_API_KEY.
+ *                 OPENAI_JUDGE_MODEL overrides the judge model.
+ */
+
+import { readFileSync } from "fs";
+import yaml from "js-yaml";
+import { z } from "zod";
+import OpenAI from "openai";
+import { zodResponseFormat } from "openai/helpers/zod";
+import { Pinecone } from "@pinecone-database/pinecone";
+
+export const RETRIEVAL_K = 10;
+export const JUDGE_MODEL =
+  process.env["OPENAI_JUDGE_MODEL"] ?? "gpt-4.1-nano";
+
+export interface BenchmarkItem {
+  query: string;
+  category: string;
+  expected_chunk_ids: string[];
+  keywords: string[];
+  reference_answer: string;
+  notes?: string;
+}
+
+export interface EvalChunk {
+  chunkId: string;
+  text: string;
+}
+
+export interface JudgeResult {
+  accuracy: number;
+  completeness: number;
+  relevance: number;
+  feedback: string;
+}
+
+export interface RetrievalItemResult {
+  query: string;
+  category: string;
+  pinpointPrecision: number;
+  mrr: number;
+  ndcg: number;
+  keywordCoverage: number;
+}
+
+export interface AnswerItemResult {
+  query: string;
+  category: string;
+  answer: string;
+  judge: JudgeResult;
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark loading
+// ---------------------------------------------------------------------------
+
+export function loadBenchmark(path: string): BenchmarkItem[] {
+  const parsed = yaml.load(readFileSync(path, "utf8"));
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${path} must be a YAML list`);
+  }
+  return parsed as BenchmarkItem[];
+}
+
+// ---------------------------------------------------------------------------
+// Retrieval (direct Pinecone call, separate from the graph's top-5)
+// ---------------------------------------------------------------------------
+
+export async function retrieveForEval(
+  index: ReturnType<Pinecone["index"]>,
+  query: string,
+  k: number,
+): Promise<EvalChunk[]> {
+  const response = await index.searchRecords({
+    query: { topK: k, inputs: { text: query } },
+  });
+  return response.result.hits.map((hit) => {
+    const f = hit.fields as Record<string, unknown>;
+    return {
+      chunkId: hit._id,
+      text: String(f["chunk_text"] ?? ""),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Retrieval metrics
+// ---------------------------------------------------------------------------
+
+export function mrrForKeyword(keyword: string, chunks: EvalChunk[]): number {
+  const kw = keyword.toLowerCase();
+  for (let i = 0; i < chunks.length; i++) {
+    if (chunks[i].text.toLowerCase().includes(kw)) return 1 / (i + 1);
+  }
+  return 0;
+}
+
+export function ndcgForKeyword(
+  keyword: string,
+  chunks: EvalChunk[],
+  k: number,
+): number {
+  const kw = keyword.toLowerCase();
+  const rels: number[] = chunks
+    .slice(0, k)
+    .map((c) => (c.text.toLowerCase().includes(kw) ? 1 : 0));
+  const dcg = rels.reduce<number>((s, r, i) => s + r / Math.log2(i + 2), 0);
+  const ideal = [...rels].sort((a, b) => b - a);
+  const idcg = ideal.reduce<number>(
+    (s, r, i) => s + r / Math.log2(i + 2),
+    0,
+  );
+  return idcg > 0 ? dcg / idcg : 0;
+}
+
+export function mean(xs: number[]): number {
+  return xs.length === 0 ? 0 : xs.reduce((s, x) => s + x, 0) / xs.length;
+}
+
+// ---------------------------------------------------------------------------
+// Per-item scoring
+// ---------------------------------------------------------------------------
+
+export interface PinpointResult {
+  pinpointPrecision: number;
+  topFiveIds: string[];
+}
+
+/**
+ * Compute pinpoint precision@5 from the production retrievals (top-5 via the
+ * compiled graph). Strict chunk-ID match.
+ */
+export function scorePinpoint(
+  topFiveIds: string[],
+  expectedChunkIds: string[],
+): PinpointResult {
+  const expectedSet = new Set(expectedChunkIds);
+  const pinpointHits = topFiveIds.filter((id) => expectedSet.has(id)).length;
+  const denom = Math.max(1, expectedChunkIds.length);
+  return {
+    pinpointPrecision: pinpointHits / denom,
+    topFiveIds,
+  };
+}
+
+export interface KeywordMetrics {
+  mrr: number;
+  ndcg: number;
+  keywordCoverage: number;
+}
+
+/**
+ * Average MRR, nDCG, and coverage of the benchmark keywords across the
+ * provided top-K chunks.
+ */
+export function scoreKeywordMetrics(
+  keywords: string[],
+  chunks: EvalChunk[],
+  k: number,
+): KeywordMetrics {
+  const mrrScores = keywords.map((kw) => mrrForKeyword(kw, chunks));
+  const ndcgScores = keywords.map((kw) => ndcgForKeyword(kw, chunks, k));
+  const mrr = mean(mrrScores);
+  const ndcg = mean(ndcgScores);
+  const kwFound = mrrScores.filter((s) => s > 0).length;
+  const keywordCoverage =
+    keywords.length === 0 ? 0 : kwFound / keywords.length;
+  return { mrr, ndcg, keywordCoverage };
+}
+
+// ---------------------------------------------------------------------------
+// LLM-as-judge
+// ---------------------------------------------------------------------------
+
+export const AnswerEvalSchema = z.object({
+  feedback: z
+    .string()
+    .describe(
+      "Concise feedback on the answer quality, comparing it to the reference answer and evaluating based on the retrieved context.",
+    ),
+  accuracy: z
+    .number()
+    .describe(
+      "How factually correct is the answer compared to the reference answer? 1 (wrong — any wrong answer must score 1) to 5 (perfectly accurate). An acceptable answer would score 3.",
+    ),
+  completeness: z
+    .number()
+    .describe(
+      "How complete is the answer in addressing all aspects of the question? 1 (missing key information) to 5 (all information from the reference answer is included). Only give 5 if ALL reference-answer information is covered.",
+    ),
+  relevance: z
+    .number()
+    .describe(
+      "How relevant is the answer to the specific question asked? 1 (off-topic) to 5 (directly addresses the question with no additional information). Only give 5 if the answer is completely on-point.",
+    ),
+});
+
+export async function judgeAnswer(
+  client: OpenAI,
+  item: BenchmarkItem,
+  generatedAnswer: string,
+): Promise<JudgeResult> {
+  const response = await client.chat.completions.parse({
+    model: JUDGE_MODEL,
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are an expert evaluator assessing the quality of answers. Evaluate the generated answer by comparing it to the reference answer. Only give 5/5 scores for perfect answers.",
+      },
+      {
+        role: "user",
+        content: `Question:
+${item.query}
+
+Generated Answer:
+${generatedAnswer}
+
+Reference Answer:
+${item.reference_answer}
+
+Please evaluate the generated answer on three dimensions:
+1. Accuracy: How factually correct is it compared to the reference answer? If the answer is wrong, accuracy MUST be 1. Only give 5/5 for perfect answers.
+2. Completeness: How thoroughly does it address all aspects of the question, covering all the information from the reference answer?
+3. Relevance: How well does it directly answer the specific question asked, giving no additional information?
+
+Provide concise feedback and scores from 1 (very poor) to 5 (ideal) for each dimension.`,
+      },
+    ],
+    response_format: zodResponseFormat(AnswerEvalSchema, "answer_eval"),
+  });
+  const parsed = response.choices[0].message.parsed;
+  if (!parsed) throw new Error("judge returned null parsed response");
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Client factories
+// ---------------------------------------------------------------------------
+
+export function createPineconeIndex(): ReturnType<Pinecone["index"]> {
+  const apiKey = process.env["PINECONE_API_KEY"];
+  const indexName = process.env["PINECONE_INDEX"];
+  if (!apiKey || !indexName) {
+    throw new Error(
+      "PINECONE_API_KEY and PINECONE_INDEX must be set to run evaluations.",
+    );
+  }
+  return new Pinecone({ apiKey }).index(indexName);
+}
+
+export function createOpenAI(): OpenAI {
+  return new OpenAI();
+}

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -25,42 +25,29 @@
  *
  * Env: PINECONE_API_KEY, PINECONE_INDEX, OPENAI_API_KEY required.
  *      OPENAI_JUDGE_MODEL overrides the judge model (default: gpt-4.1-nano).
+ *
+ * Scoring logic lives in `eval/core.ts` so it's reusable by the API routes
+ * that back `/evaluations`. This file handles CLI orchestration + reporting.
  */
 
 import "dotenv/config";
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { writeFileSync, mkdirSync } from "fs";
 import { resolve, dirname } from "path";
 import { execSync } from "child_process";
-import yaml from "js-yaml";
-import { z } from "zod";
-import OpenAI from "openai";
-import { zodResponseFormat } from "openai/helpers/zod";
-import { Pinecone } from "@pinecone-database/pinecone";
 import { graph } from "../pipeline/graph";
-
-const RETRIEVAL_K = 10;
-const JUDGE_MODEL = process.env["OPENAI_JUDGE_MODEL"] ?? "gpt-4.1-nano";
-
-interface BenchmarkItem {
-  query: string;
-  category: string;
-  expected_chunk_ids: string[];
-  keywords: string[];
-  reference_answer: string;
-  notes?: string;
-}
-
-interface EvalChunk {
-  chunkId: string;
-  text: string;
-}
-
-interface JudgeResult {
-  accuracy: number;
-  completeness: number;
-  relevance: number;
-  feedback: string;
-}
+import {
+  JUDGE_MODEL,
+  RETRIEVAL_K,
+  createOpenAI,
+  createPineconeIndex,
+  judgeAnswer,
+  loadBenchmark,
+  mean,
+  retrieveForEval,
+  scoreKeywordMetrics,
+  scorePinpoint,
+  type JudgeResult,
+} from "./core";
 
 interface ItemResult {
   query: string;
@@ -71,139 +58,6 @@ interface ItemResult {
   keywordCoverage: number;
   judge?: JudgeResult;
   answer: string;
-}
-
-// ---------------------------------------------------------------------------
-// Benchmark loading
-// ---------------------------------------------------------------------------
-
-function loadBenchmark(path: string): BenchmarkItem[] {
-  const parsed = yaml.load(readFileSync(path, "utf8"));
-  if (!Array.isArray(parsed)) {
-    throw new Error(`${path} must be a YAML list`);
-  }
-  return parsed as BenchmarkItem[];
-}
-
-// ---------------------------------------------------------------------------
-// Retrieval (k=10) — direct Pinecone call, separate from the graph's top-5
-// ---------------------------------------------------------------------------
-
-async function retrieveForEval(
-  index: ReturnType<Pinecone["index"]>,
-  query: string,
-  k: number
-): Promise<EvalChunk[]> {
-  const response = await index.searchRecords({
-    query: { topK: k, inputs: { text: query } },
-  });
-  return response.result.hits.map((hit) => {
-    const f = hit.fields as Record<string, unknown>;
-    return {
-      chunkId: hit._id,
-      text: String(f["chunk_text"] ?? ""),
-    };
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Retrieval metrics
-// ---------------------------------------------------------------------------
-
-function mrrForKeyword(keyword: string, chunks: EvalChunk[]): number {
-  const kw = keyword.toLowerCase();
-  for (let i = 0; i < chunks.length; i++) {
-    if (chunks[i].text.toLowerCase().includes(kw)) return 1 / (i + 1);
-  }
-  return 0;
-}
-
-function ndcgForKeyword(
-  keyword: string,
-  chunks: EvalChunk[],
-  k: number
-): number {
-  const kw = keyword.toLowerCase();
-  const rels: number[] = chunks
-    .slice(0, k)
-    .map((c) => (c.text.toLowerCase().includes(kw) ? 1 : 0));
-  const dcg = rels.reduce<number>((s, r, i) => s + r / Math.log2(i + 2), 0);
-  const ideal = [...rels].sort((a, b) => b - a);
-  const idcg = ideal.reduce<number>(
-    (s, r, i) => s + r / Math.log2(i + 2),
-    0
-  );
-  return idcg > 0 ? dcg / idcg : 0;
-}
-
-function mean(xs: number[]): number {
-  return xs.length === 0 ? 0 : xs.reduce((s, x) => s + x, 0) / xs.length;
-}
-
-// ---------------------------------------------------------------------------
-// LLM-as-judge
-// ---------------------------------------------------------------------------
-
-const AnswerEvalSchema = z.object({
-  feedback: z
-    .string()
-    .describe(
-      "Concise feedback on the answer quality, comparing it to the reference answer and evaluating based on the retrieved context."
-    ),
-  accuracy: z
-    .number()
-    .describe(
-      "How factually correct is the answer compared to the reference answer? 1 (wrong — any wrong answer must score 1) to 5 (perfectly accurate). An acceptable answer would score 3."
-    ),
-  completeness: z
-    .number()
-    .describe(
-      "How complete is the answer in addressing all aspects of the question? 1 (missing key information) to 5 (all information from the reference answer is included). Only give 5 if ALL reference-answer information is covered."
-    ),
-  relevance: z
-    .number()
-    .describe(
-      "How relevant is the answer to the specific question asked? 1 (off-topic) to 5 (directly addresses the question with no additional information). Only give 5 if the answer is completely on-point."
-    ),
-});
-
-async function judgeAnswer(
-  client: OpenAI,
-  item: BenchmarkItem,
-  generatedAnswer: string
-): Promise<JudgeResult> {
-  const response = await client.chat.completions.parse({
-    model: JUDGE_MODEL,
-    messages: [
-      {
-        role: "system",
-        content:
-          "You are an expert evaluator assessing the quality of answers. Evaluate the generated answer by comparing it to the reference answer. Only give 5/5 scores for perfect answers.",
-      },
-      {
-        role: "user",
-        content: `Question:
-${item.query}
-
-Generated Answer:
-${generatedAnswer}
-
-Reference Answer:
-${item.reference_answer}
-
-Please evaluate the generated answer on three dimensions:
-1. Accuracy: How factually correct is it compared to the reference answer? If the answer is wrong, accuracy MUST be 1. Only give 5/5 for perfect answers.
-2. Completeness: How thoroughly does it address all aspects of the question, covering all the information from the reference answer?
-3. Relevance: How well does it directly answer the specific question asked, giving no additional information?
-
-Provide concise feedback and scores from 1 (very poor) to 5 (ideal) for each dimension.`,
-      },
-    ],
-    response_format: zodResponseFormat(AnswerEvalSchema, "answer_eval"),
-  });
-  const parsed = response.choices[0].message.parsed;
-  if (!parsed) throw new Error("judge returned null parsed response");
-  return parsed;
 }
 
 // ---------------------------------------------------------------------------
@@ -330,51 +184,51 @@ function buildReport(results: ItemResult[], skipJudge: boolean): string {
   lines.push("## What the metrics mean");
   lines.push("");
   lines.push(
-    "Each question goes through two stages: the system **retrieves** source passages, then a model **generates** an answer from them. The retrieval metrics score the first stage; the judge metrics score the second."
+    "Each question goes through two stages: the system **retrieves** source passages, then a model **generates** an answer from them. The retrieval metrics score the first stage; the judge metrics score the second.",
   );
   lines.push("");
   lines.push("### Retrieval metrics");
   lines.push("");
   lines.push(
-    "**pinpoint_precision@5** (0 to 1) — Did the system pull back the exact chunks we labelled as the \"right answer\"? We look at the top 5 results and count how many expected chunks appear. 1.0 means all of them made the top 5; 0.0 means none did. This is the strictest measure — it rewards an exact chunk match, not \"close enough.\""
+    "**pinpoint_precision@5** (0 to 1) — Did the system pull back the exact chunks we labelled as the \"right answer\"? We look at the top 5 results and count how many expected chunks appear. 1.0 means all of them made the top 5; 0.0 means none did. This is the strictest measure — it rewards an exact chunk match, not \"close enough.\"",
   );
   lines.push("");
   lines.push(
-    "**MRR** — Mean Reciprocal Rank (0 to 1). For each keyword from the source passage, how high up the result list did it first appear? A keyword in the first result scores 1.0; in the second, 0.5; in the third, 0.33; and so on. We average across all keywords. Higher is better — it means relevant content is near the top, where the answer generator is most likely to use it."
+    "**MRR** — Mean Reciprocal Rank (0 to 1). For each keyword from the source passage, how high up the result list did it first appear? A keyword in the first result scores 1.0; in the second, 0.5; in the third, 0.33; and so on. We average across all keywords. Higher is better — it means relevant content is near the top, where the answer generator is most likely to use it.",
   );
   lines.push("");
   lines.push(
-    "**nDCG** — Normalized Discounted Cumulative Gain (0 to 1). Similar in spirit to MRR, but rewards having relevant chunks appear anywhere in the top results with extra weight on higher positions. 1.0 means the ideal ranking — every chunk containing the keyword is stacked at the top. Complements MRR when the same keyword appears in several chunks."
+    "**nDCG** — Normalized Discounted Cumulative Gain (0 to 1). Similar in spirit to MRR, but rewards having relevant chunks appear anywhere in the top results with extra weight on higher positions. 1.0 means the ideal ranking — every chunk containing the keyword is stacked at the top. Complements MRR when the same keyword appears in several chunks.",
   );
   lines.push("");
   lines.push(
-    "**keyword_coverage** (0% to 100%) — Of the keywords we listed as terms a correct answer should convey, what fraction was found *somewhere* in the top 10 retrieved chunks? 100% means every keyword was available for the model to cite. If a keyword is missing from retrieval entirely, the model can't include it in the answer. Blunter than MRR/nDCG: it only cares about presence, not ranking."
+    "**keyword_coverage** (0% to 100%) — Of the keywords we listed as terms a correct answer should convey, what fraction was found *somewhere* in the top 10 retrieved chunks? 100% means every keyword was available for the model to cite. If a keyword is missing from retrieval entirely, the model can't include it in the answer. Blunter than MRR/nDCG: it only cares about presence, not ranking.",
   );
   lines.push("");
   if (!skipJudge) {
     lines.push("### Answer metrics (LLM-as-judge)");
     lines.push("");
     lines.push(
-      `A cheap, fast language model (here: \`${JUDGE_MODEL}\`) reads the generated answer alongside our hand-written reference answer and scores three dimensions from 1 (very poor) to 5 (perfect). The judge is instructed that 5 is reserved for perfect answers.`
+      `A cheap, fast language model (here: \`${JUDGE_MODEL}\`) reads the generated answer alongside our hand-written reference answer and scores three dimensions from 1 (very poor) to 5 (perfect). The judge is instructed that 5 is reserved for perfect answers.`,
     );
     lines.push("");
     lines.push(
-      "**judge_accuracy** (1 to 5) — Is the answer *factually correct* compared to the reference? 1 = wrong (any factual error forces a 1). 3 = acceptable. 5 = perfectly accurate."
+      "**judge_accuracy** (1 to 5) — Is the answer *factually correct* compared to the reference? 1 = wrong (any factual error forces a 1). 3 = acceptable. 5 = perfectly accurate.",
     );
     lines.push("");
     lines.push(
-      "**judge_completeness** (1 to 5) — Does the answer cover *everything* the reference answer covers? 1 = key information is missing. 5 is only awarded when every point from the reference is present."
+      "**judge_completeness** (1 to 5) — Does the answer cover *everything* the reference answer covers? 1 = key information is missing. 5 is only awarded when every point from the reference is present.",
     );
     lines.push("");
     lines.push(
-      "**judge_relevance** (1 to 5) — Does the answer stay *on-topic*? 1 = off-topic or padded with irrelevant material. 5 = directly addresses the specific question without extras."
+      "**judge_relevance** (1 to 5) — Does the answer stay *on-topic*? 1 = off-topic or padded with irrelevant material. 5 = directly addresses the specific question without extras.",
     );
     lines.push("");
   }
   lines.push("### How to read the results");
   lines.push("");
   lines.push(
-    "The metrics are designed to surface *different kinds* of failures. A high pinpoint_precision but low judge_accuracy means retrieval worked but the model misread the source. A low keyword_coverage with a high judge score means the model is correct in spite of weak retrieval. Watch the combinations, not any single number."
+    "The metrics are designed to surface *different kinds* of failures. A high pinpoint_precision but low judge_accuracy means retrieval worked but the model misread the source. A low keyword_coverage with a high judge score means the model is correct in spite of weak retrieval. Watch the combinations, not any single number.",
   );
   lines.push("");
 
@@ -387,7 +241,7 @@ function buildReport(results: ItemResult[], skipJudge: boolean): string {
           r.judge &&
           (r.judge.accuracy < 3 ||
             r.judge.completeness < 3 ||
-            r.judge.relevance < 3)
+            r.judge.relevance < 3),
       );
     if (lowScorers.length > 0) {
       lines.push("## Judge feedback — items scoring <3 on any dimension");
@@ -395,7 +249,7 @@ function buildReport(results: ItemResult[], skipJudge: boolean): string {
       for (const { r, i } of lowScorers) {
         const j = r.judge!;
         lines.push(
-          `**#${i + 1}** (${r.category}) — acc ${fmt(j.accuracy)} / comp ${fmt(j.completeness)} / rel ${fmt(j.relevance)}`
+          `**#${i + 1}** (${r.category}) — acc ${fmt(j.accuracy)} / comp ${fmt(j.completeness)} / rel ${fmt(j.relevance)}`,
         );
         lines.push("");
         lines.push(`> ${r.query}`);
@@ -418,50 +272,45 @@ async function main(): Promise<void> {
   const skipJudge = process.argv.includes("--skip-judge");
   const benchmarkPath = resolve(
     process.cwd(),
-    args[0] ?? "eval/benchmarks/pilot.yaml"
+    args[0] ?? "eval/benchmarks/pilot.yaml",
   );
 
   const items = loadBenchmark(benchmarkPath);
   console.log(
     `Running ${items.length} items from ${benchmarkPath}` +
-      (skipJudge ? " (skipping judge)" : ` (judge: ${JUDGE_MODEL})`)
+      (skipJudge ? " (skipping judge)" : ` (judge: ${JUDGE_MODEL})`),
   );
   console.log();
 
-  const pc = new Pinecone({ apiKey: process.env["PINECONE_API_KEY"]! });
-  const pineconeIndex = pc.index(process.env["PINECONE_INDEX"]!);
-  const openai = new OpenAI();
+  const pineconeIndex = createPineconeIndex();
+  const openai = createOpenAI();
 
   const results: ItemResult[] = [];
 
   for (const [i, item] of items.entries()) {
     process.stdout.write(
-      `[${i + 1}/${items.length}] ${item.query.slice(0, 60)}… `
+      `[${i + 1}/${items.length}] ${item.query.slice(0, 60)}… `,
     );
 
     // Production retrieval + answer via the compiled graph (top-5)
     const state = await graph.invoke({ query: item.query });
     const topFiveIds = (state.retrievals ?? []).map((r) => r.chunkId);
-    const expectedSet = new Set(item.expected_chunk_ids);
-    const pinpointHits = topFiveIds.filter((id) => expectedSet.has(id)).length;
-    const pinpointPrecision =
-      pinpointHits / item.expected_chunk_ids.length;
+    const { pinpointPrecision } = scorePinpoint(
+      topFiveIds,
+      item.expected_chunk_ids,
+    );
 
     // Separate top-10 retrieval for keyword-based retrieval metrics
     const topTen = await retrieveForEval(
       pineconeIndex,
       item.query,
-      RETRIEVAL_K
+      RETRIEVAL_K,
     );
-    const mrrScores = item.keywords.map((k) => mrrForKeyword(k, topTen));
-    const ndcgScores = item.keywords.map((k) =>
-      ndcgForKeyword(k, topTen, RETRIEVAL_K)
+    const { mrr, ndcg, keywordCoverage } = scoreKeywordMetrics(
+      item.keywords,
+      topTen,
+      RETRIEVAL_K,
     );
-    const mrr = mean(mrrScores);
-    const ndcg = mean(ndcgScores);
-    const kwFound = mrrScores.filter((s) => s > 0).length;
-    const keywordCoverage =
-      item.keywords.length === 0 ? 0 : kwFound / item.keywords.length;
 
     // LLM judge
     const answer = state.answer ?? "";
@@ -472,7 +321,7 @@ async function main(): Promise<void> {
       } catch (err) {
         console.log();
         console.error(
-          `  judge error: ${err instanceof Error ? err.message : String(err)}`
+          `  judge error: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }
@@ -502,7 +351,7 @@ async function main(): Promise<void> {
 
   const outPath = resolve(
     process.cwd(),
-    `eval/results/${isoDate()}-${gitShortSha()}.md`
+    `eval/results/${isoDate()}-${gitShortSha()}.md`,
   );
   mkdirSync(dirname(outPath), { recursive: true });
   writeFileSync(outPath, report);


### PR DESCRIPTION
## Summary
- New `/evaluations` dashboard: two sections (Retrieval, Answer), each with a "Run evaluation" button, three colour-coded metric cards, and a bar chart of the score by category. Restyled from the Gradio prototype to match the app's muted-green theme (`Card`, `SERIF`, no bright primaries, no emoji headers).
- Streaming `POST /api/evaluations/retrieval` and `POST /api/evaluations/answer` endpoints emit NDJSON — one item per line, then a terminal `{ done: true, summary }` frame. No new npm deps, no SSE library.
- `eval/runner.ts` refactored to call shared primitives in `eval/core.ts` (benchmark load, Pinecone/OpenAI clients, MRR/nDCG/coverage, judge). CLI `pnpm eval` behaviour unchanged.

## Test plan
- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean (pre-existing warning in `scripts/verify-eval.ts` is unrelated)
- [ ] `pnpm eval --skip-judge` still produces the same averages and markdown report shape
- [ ] Click "Run evaluation" on the Retrieval section — progress indicator updates as items stream in; three metric cards + category bar chart render on completion
- [ ] Click "Run evaluation" on the Answer section — same, with judge metrics on a 1–5 scale
- [ ] Threshold colours match the spec (green `#9cc9a9`/`#2d4a35`, amber `#fab89a`/`#8b4a2f`, red `#c5a0a5`/`#8b3a2f`); boundary values (0.9, 0.75, 4.5, 4.0) land on the higher tier

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
