### PR TITLE
AGENT: chunker — merge small parent frames + drop heading-residual chunks

### DIFF
--- a/eval/benchmarks/pilot.yaml
+++ b/eval/benchmarks/pilot.yaml
@@ -25,7 +25,7 @@
 - query: "When can a broker-dealer skip the locate requirement for a short sale?"
   category: Direct fact
   expected_chunk_ids:
-    - "17-CFR-242.203::(b)(2)::p0"
+    - "17-CFR-242.203::(b)(2)(i)::p0"
   keywords:
     - "bona-fide market making"
     - "market maker"

--- a/ingest/ARCHITECTURE.md
+++ b/ingest/ARCHITECTURE.md
@@ -97,6 +97,27 @@ Within either mode, a frame whose prose exceeds the target token budget
 is split across multiple chunks via the sentence packer with ~50-token
 overlap between adjacent chunks.
 
+**Small-frame merge + heading-residual drop (regulatory mode only).** The
+CFR pattern of an intro sentence under a header-with-marker followed by
+bulleted sub-items was producing near-empty chunks at the parent level
+(e.g. `(b)(2)` → `"Exceptions. The locate requirement does not apply to:"`)
+and heading-title-only chunks where a header line's marker had no body
+before the next sub-marker (e.g. `(b)` → `"Locate" requirement for short sales.`).
+After frame collection, `chunkRegulatory` post-processes the frame list:
+
+1. **Drop** frames whose only non-blank content is the residual extracted
+   from a header line — these carry a heading title and no prose.
+2. **Merge** frames whose body has fewer than `SMALL_FRAME_WORDS` (default
+   `15`) words into the immediately-following deeper-level child frame
+   (i.e. a frame whose `paragraphPath` strictly extends the current
+   frame's). The parent text is prepended to the child's first chunk; the
+   small parent is not emitted as its own chunk. Merging is downward only
+   — a small frame followed by a same-level sibling or shallower ancestor
+   is emitted as-is. Only the _first_ child receives the merged prefix.
+
+Both transformations are internal to regulatory mode; fallback-mode chunk
+IDs and emission are unaffected.
+
 **Token heuristic:** `1 token ≈ 0.75 words` → target word budget = 375 words, overlap = 38 words.
 
 **Citation protection:** sentence splitter guards against splitting on `.` preceded by a digit or uppercase letter, preserving strings like `17 CFR 240.15l-1` and `U.S.C.` within a single chunk.

--- a/ingest/chunk.ts
+++ b/ingest/chunk.ts
@@ -35,6 +35,14 @@ const WORDS_PER_TOKEN = 0.75;
 const TARGET_WORDS = Math.round(TARGET_TOKENS * WORDS_PER_TOKEN); // ~375
 const OVERLAP_WORDS = Math.round(OVERLAP_TOKENS * WORDS_PER_TOKEN); // ~38
 
+// Regulatory-mode: a closed paragraph frame whose body has fewer than this
+// many words is merged into the immediately-following child frame (i.e. a
+// frame one level deeper in the paragraph-marker stack) rather than emitted
+// as its own chunk. Frames that are exclusively the residual of a header
+// line (heading title stripped of its marker) are dropped entirely — see
+// `chunkRegulatory`.
+export const SMALL_FRAME_WORDS = 15;
+
 const HEADER_RE = /^(#{1,3})\s+(.+)$/;
 
 // ---------------------------------------------------------------------------
@@ -361,10 +369,19 @@ function stripDetectedMarker(line: string): string {
     .trim();
 }
 
+interface FrameLine {
+  text: string;
+  // `true` iff this line was produced by stripping the paragraph marker
+  // from a Markdown header line (i.e. the heading's title prose). Frames
+  // whose lines are ALL header-residuals contain no real body — they are
+  // just a heading title — and are dropped during emission.
+  fromHeaderResidual: boolean;
+}
+
 interface ParagraphFrame {
   paragraphPath: string; // concatenation of marker stack, e.g. "(a)(2)(ii)"
   headingPath: string;
-  lines: string[];
+  lines: FrameLine[];
 }
 
 function chunkRegulatory(
@@ -376,7 +393,11 @@ function chunkRegulatory(
   const headingStack: string[] = ["", "", ""];
   const markerStack: ParagraphMarker[] = [];
   const frames: ParagraphFrame[] = [];
-  let current: ParagraphFrame = { paragraphPath: "", headingPath: "", lines: [] };
+  let current: ParagraphFrame = {
+    paragraphPath: "",
+    headingPath: "",
+    lines: [],
+  };
 
   function pathFromStack(): string {
     return markerStack.map((m) => m.marker).join("");
@@ -395,7 +416,7 @@ function chunkRegulatory(
   }
 
   function closeFrame(): void {
-    if (current.lines.some((l) => l.trim().length > 0)) {
+    if (current.lines.some((l) => l.text.trim().length > 0)) {
       frames.push(current);
     }
     openFrame();
@@ -433,7 +454,9 @@ function chunkRegulatory(
       // are purely structural — their title is not treated as chunk prose.
       if (headerMarker) {
         const residual = stripDetectedMarker(line);
-        if (residual.length > 0) current.lines.push(residual);
+        if (residual.length > 0) {
+          current.lines.push({ text: residual, fromHeaderResidual: true });
+        }
       }
       continue;
     }
@@ -450,13 +473,69 @@ function chunkRegulatory(
       markerStack.push(marker);
       openFrame();
       const residual = stripDetectedMarker(line);
-      if (residual.length > 0) current.lines.push(residual);
+      if (residual.length > 0) {
+        current.lines.push({ text: residual, fromHeaderResidual: false });
+      }
       continue;
     }
 
-    current.lines.push(line);
+    current.lines.push({ text: line, fromHeaderResidual: false });
   }
   closeFrame();
+
+  // -------------------------------------------------------------------
+  // Post-process: drop header-residual-only frames, merge small parent
+  // frames into the first deeper-level child frame.
+  // -------------------------------------------------------------------
+
+  // Step 1 — drop frames whose only content is the residual of a header
+  // line (a heading title with its marker stripped and no body prose).
+  // These carry no real content and are never useful as retrievals.
+  const afterDrop: ParagraphFrame[] = frames.filter((frame) => {
+    const nonBlank = frame.lines.filter((l) => l.text.trim().length > 0);
+    if (nonBlank.length === 0) return false;
+    // Keep the frame iff at least one non-blank line is body prose rather
+    // than a header residual.
+    return nonBlank.some((l) => !l.fromHeaderResidual);
+  });
+
+  // Step 2 — merge small parent frames forward into the next deeper-level
+  // child frame. A small frame is one whose body has fewer than
+  // SMALL_FRAME_WORDS words. "Deeper-level child" is defined structurally
+  // against the paragraph-marker stack: the next frame must have a strictly
+  // longer `paragraphPath` that starts with the current frame's path, and
+  // the current frame must itself have a non-empty path (otherwise the two
+  // frames are independent heading-scoped siblings, not parent/child).
+  // If the next frame is a sibling, an ancestor, or a heading-scoped peer,
+  // the small frame is emitted as-is — we never merge upward.
+  const mergedFrames: ParagraphFrame[] = [];
+  for (let i = 0; i < afterDrop.length; i++) {
+    const frame = afterDrop[i];
+    const frameText = frame.lines.map((l) => l.text).join("\n").trim();
+    const frameWords = wordCount(frameText);
+    const next = afterDrop[i + 1];
+
+    const isSmall = frameWords > 0 && frameWords < SMALL_FRAME_WORDS;
+    const nextIsChild =
+      next !== undefined &&
+      frame.paragraphPath.length > 0 &&
+      next.paragraphPath.length > frame.paragraphPath.length &&
+      next.paragraphPath.startsWith(frame.paragraphPath);
+
+    if (isSmall && nextIsChild) {
+      // Prepend this frame's text to the next child frame, keeping the
+      // child's provenance flags intact. The prepended line is marked as
+      // body prose (not header-residual) so it cannot cause the combined
+      // frame to be dropped by Step 1 semantics on a later pass.
+      next.lines = [
+        { text: frameText, fromHeaderResidual: false },
+        ...next.lines,
+      ];
+      continue; // do not emit the small parent frame itself
+    }
+
+    mergedFrames.push(frame);
+  }
 
   // Convert frames to chunks. A frame may produce multiple chunks if its
   // prose exceeds the target-token budget; suffix with `p${N}` in order.
@@ -472,14 +551,14 @@ function chunkRegulatory(
   // Resolve a slug once per frame so all chunks in the same frame share a
   // base ID, disambiguated by ::p0, ::p1, ….
   const slugByFrame = new Map<ParagraphFrame, string>();
-  for (const frame of frames) {
+  for (const frame of mergedFrames) {
     if (frame.paragraphPath.length === 0) {
       slugByFrame.set(frame, resolveSlug(frame.headingPath, slugCounts));
     }
   }
 
-  for (const frame of frames) {
-    const text = frame.lines.join("\n").trim();
+  for (const frame of mergedFrames) {
+    const text = frame.lines.map((l) => l.text).join("\n").trim();
     if (text.length === 0) continue;
 
     const sentences = splitSentences(text);

--- a/tests/unit/chunk.test.ts
+++ b/tests/unit/chunk.test.ts
@@ -260,7 +260,9 @@ interest ahead of the customer's.
 
 ### (2) Care obligation.
 
-The broker-dealer must exercise reasonable diligence, care, and skill.
+The broker-dealer must exercise reasonable diligence, care, and skill to
+understand the potential risks, rewards, and costs associated with the
+recommendation being made to the retail customer.
 
 - (ii) Have a reasonable basis to believe that the recommendation is in the
   best interest of a particular retail customer based on that customer's
@@ -371,5 +373,157 @@ describe("Regulatory mode: MSRB paragraph paths", () => {
     const chunks = chunkDocument(FIXTURE_MSRB, MSRB_METADATA);
     const ids = chunks.map((c) => c.id);
     expect(ids).toContain("MSRB-Rule-G-18::(c)(i)::p0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regulatory mode: heading-residual drop + small-parent-merge (issue #49)
+// ---------------------------------------------------------------------------
+
+describe("Regulatory mode: drop heading-residual-only frames", () => {
+  const SEC_META: Omit<
+    ChunkMetadata,
+    "headingPath" | "chunkIndex" | "paragraphPath"
+  > = {
+    ...BASE_METADATA,
+    authority: "SEC",
+    citationId: "TEST-DOC",
+  };
+
+  it("does not emit a chunk whose only content is a header residual", () => {
+    // `## (a) Short title.` followed immediately by `### (1) Body…` means the
+    // `(a)` frame contains only the residual `Short title.` — a heading
+    // title with no prose. That frame must be dropped.
+    const fixture = `
+# Section
+
+## (a) Short title.
+
+### (1) Body text for the first sub-paragraph that is long enough to be
+emitted as its own chunk without triggering the small-frame merge rule
+and thus produces a stable chunk id.
+`.trim();
+
+    const chunks = chunkDocument(fixture, SEC_META);
+    const ids = chunks.map((c) => c.id);
+
+    expect(ids).not.toContain("TEST-DOC::(a)::p0");
+    expect(ids).toContain("TEST-DOC::(a)(1)::p0");
+  });
+});
+
+describe("Regulatory mode: merge small parent frames into first child", () => {
+  const SEC_META: Omit<
+    ChunkMetadata,
+    "headingPath" | "chunkIndex" | "paragraphPath"
+  > = {
+    ...BASE_METADATA,
+    authority: "SEC",
+    citationId: "TEST-DOC",
+  };
+
+  it("prepends a small parent frame's prose to the first deeper-level child", () => {
+    // Mirrors Reg SHO `(b)(2)`: an `### (2) Exceptions.` header with a brief
+    // intro sentence under it, followed by bulleted sub-items `(i)`, `(ii)`.
+    // The parent frame body is below SMALL_FRAME_WORDS so it must be merged
+    // into `(i)` (the first child) and NOT emitted as its own chunk. The
+    // sibling `(ii)` receives no merge — only the first child does.
+    const fixture = `
+# Section
+
+## (b) Parent paragraph with more than fifteen words so that it is comfortably
+above the small-frame threshold and gets emitted as its own chunk without
+any special handling.
+
+### (2) Exceptions.
+
+The locate requirement does not apply to:
+
+- (i) Short sales by a broker-dealer in connection with bona-fide market
+  making activity in the security for which the short sale is effected.
+- (ii) Short sales effected by a broker-dealer for an account of a
+  registered market maker on the same bona-fide market-making basis.
+`.trim();
+
+    const chunks = chunkDocument(fixture, SEC_META);
+    const ids = chunks.map((c) => c.id);
+
+    // The small parent frame must NOT be emitted.
+    expect(ids).not.toContain("TEST-DOC::(b)(2)::p0");
+
+    // The first child frame carries the merged intro sentence at its head,
+    // BEFORE its own prose.
+    const firstChild = chunks.find(
+      (c) => c.id === "TEST-DOC::(b)(2)(i)::p0"
+    );
+    expect(firstChild).toBeDefined();
+    const introIdx = firstChild!.text.indexOf(
+      "The locate requirement does not apply to:"
+    );
+    const ownProseIdx = firstChild!.text.indexOf("Short sales by a broker-dealer");
+    expect(introIdx).toBeGreaterThanOrEqual(0);
+    expect(ownProseIdx).toBeGreaterThan(introIdx);
+    // Sanity: the child's own prose is preserved after the merged prefix.
+    expect(firstChild!.text).toContain("bona-fide market");
+
+    // The sibling `(ii)` does NOT receive the merged prefix.
+    const secondChild = chunks.find(
+      (c) => c.id === "TEST-DOC::(b)(2)(ii)::p0"
+    );
+    expect(secondChild).toBeDefined();
+    expect(secondChild!.text).not.toContain(
+      "The locate requirement does not apply to:"
+    );
+  });
+});
+
+describe("Regulatory mode: small frame with no deeper child is emitted as-is", () => {
+  const SEC_META: Omit<
+    ChunkMetadata,
+    "headingPath" | "chunkIndex" | "paragraphPath"
+  > = {
+    ...BASE_METADATA,
+    authority: "SEC",
+    citationId: "TEST-DOC",
+  };
+
+  it("does not merge upward into a same-level sibling", () => {
+    // `(a)` and `(b)` are siblings at the same marker depth. A small `(a)`
+    // frame must NOT be merged into `(b)` — merging is downward (into a
+    // child) only. The small frame is emitted as-is.
+    const fixture = `
+# Section
+
+## (a) Short intro.
+
+Brief sentence with only a few words.
+
+## (b) Sibling paragraph containing enough prose to clear the small-frame
+threshold and be emitted on its own without special handling.
+`.trim();
+
+    const chunks = chunkDocument(fixture, SEC_META);
+    const ids = chunks.map((c) => c.id);
+
+    expect(ids).toContain("TEST-DOC::(a)::p0");
+    expect(ids).toContain("TEST-DOC::(b)::p0");
+
+    // The `(a)` chunk's text still contains its own intro — it has not been
+    // swallowed by `(b)`.
+    const a = chunks.find((c) => c.id === "TEST-DOC::(a)::p0");
+    expect(a).toBeDefined();
+    expect(a!.text).toContain("Brief sentence with only a few words.");
+
+    // And `(b)` does not contain `(a)`'s prose.
+    const b = chunks.find((c) => c.id === "TEST-DOC::(b)::p0");
+    expect(b).toBeDefined();
+    expect(b!.text).not.toContain("Brief sentence with only a few words.");
+  });
+});
+
+describe("Regulatory mode: SMALL_FRAME_WORDS constant", () => {
+  it("is exported with the documented default value", async () => {
+    const mod = await import("../../ingest/chunk");
+    expect(mod.SMALL_FRAME_WORDS).toBe(15);
   });
 });


### PR DESCRIPTION
Closes #49

## Summary

- Regulatory-mode chunker (`ingest/chunk.ts`) no longer emits near-empty chunks for two CFR patterns: (1) headers with a marker but no body before the next sub-marker, and (2) parent paragraphs that are a one-line intro to a bulleted sub-list.
- Fix: line provenance is tracked structurally (`FrameLine.fromHeaderResidual`); after frame collection, `chunkRegulatory` drops frames whose only content is a header residual, then merges frames under `SMALL_FRAME_WORDS` (=15) into the first deeper-level child frame (prefix match on `paragraphPath`, downward only).
- `eval/benchmarks/pilot.yaml` updated: `17-CFR-242.203::(b)(2)::p0` → `17-CFR-242.203::(b)(2)(i)::p0`, which now carries the merged intro + bona-fide market-making exception. `pnpm verify-eval` resolves 33/33 chunks.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test tests/unit/chunk.test.ts` — 18/18 passing (including 3 new: drop-heading-residual, merge-intro-into-child, no-merge-when-no-child)
- [x] `pnpm verify-eval` — 30/30 items, 33/33 chunk IDs resolve
- [x] Determinism: `pnpm verify-eval` produces byte-identical output on re-run
- [ ] **Post-merge operational step (out of scope for this PR):** reingest the live Pinecone index so the dashboard sees the new chunks. Until then, prod retrieval still reflects pre-fix chunking.