### PR TITLE
Fix dashboard input/button height, citation circles, and confidence tooltip

### DIFF
--- a/app/_components/answer-card.tsx
+++ b/app/_components/answer-card.tsx
@@ -80,6 +80,9 @@ export function AnswerCard({
   );
 }
 
+const CONFIDENCE_TOOLTIP =
+  "Based on the semantic similarity score of the best-matching source retrieved for your question. High = score ≥ 0.8, Medium = score ≥ 0.55, Low = score < 0.55.";
+
 function ConfidenceBadge({
   tier,
 }: {
@@ -89,36 +92,32 @@ function ConfidenceBadge({
   const label =
     tier === "HIGH" ? "High" : tier === "MEDIUM" ? "Medium" : "Low";
 
-  if (isPeach) {
-    return (
-      <div className="flex items-center gap-3 rounded-2xl bg-[#fde4d4]/70 px-3.5 py-2 ring-1 ring-[#fab89a]/40">
-        <div className="flex flex-col items-end leading-none">
-          <span className="text-[9px] uppercase tracking-[0.2em] text-[#8b4a2f]">
-            Confidence
-          </span>
-          <span
-            className="mt-1 text-[18px] leading-none tracking-tight text-[#6b2d0e]"
-            style={SERIF}
-          >
-            {label}
-          </span>
-        </div>
-        <div className="flex h-7 w-7 items-center justify-center rounded-full bg-white ring-1 ring-[#fab89a]/50">
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-            <path
-              d="M3.5 7L6 9.5L10.5 4.5"
-              stroke="#8b4a2f"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </div>
+  const badge = isPeach ? (
+    <div className="flex items-center gap-3 rounded-2xl bg-[#fde4d4]/70 px-3.5 py-2 ring-1 ring-[#fab89a]/40">
+      <div className="flex flex-col items-end leading-none">
+        <span className="text-[9px] uppercase tracking-[0.2em] text-[#8b4a2f]">
+          Confidence
+        </span>
+        <span
+          className="mt-1 text-[18px] leading-none tracking-tight text-[#6b2d0e]"
+          style={SERIF}
+        >
+          {label}
+        </span>
       </div>
-    );
-  }
-
-  return (
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-white ring-1 ring-[#fab89a]/50">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <path
+            d="M3.5 7L6 9.5L10.5 4.5"
+            stroke="#8b4a2f"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+    </div>
+  ) : (
     <div className="flex items-center gap-3 rounded-2xl bg-[#dfeee3]/70 px-3.5 py-2 ring-1 ring-[#9cc9a9]/40">
       <div className="flex flex-col items-end leading-none">
         <span className="text-[9px] uppercase tracking-[0.2em] text-[#2d4a35]/70">
@@ -140,6 +139,25 @@ function ConfidenceBadge({
             strokeLinecap="round"
           />
         </svg>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="group relative">
+      {badge}
+      <div
+        role="tooltip"
+        className="pointer-events-none absolute right-0 top-full z-50 mt-2 w-60 rounded-xl bg-[#1f2a23] px-3.5 py-2.5 text-[12px] leading-relaxed text-white/90 opacity-0 shadow-[0_8px_24px_-4px_rgba(31,42,35,0.4)] transition-opacity duration-150 group-hover:opacity-100"
+      >
+        <span className="mb-1 block text-[9px] uppercase tracking-[0.18em] text-white/50">
+          How confidence is determined
+        </span>
+        {CONFIDENCE_TOOLTIP}
+        <span
+          aria-hidden
+          className="absolute right-4 top-0 -translate-y-full border-4 border-transparent border-b-[#1f2a23]"
+        />
       </div>
     </div>
   );

--- a/app/_components/citation-chip.tsx
+++ b/app/_components/citation-chip.tsx
@@ -32,7 +32,7 @@ export function CitationChip({
         type="button"
         onClick={() => onActivate?.(n)}
         aria-label={`Open citation ${n}`}
-        className="mx-[2px] inline-flex h-5 min-w-[22px] -translate-y-[1px] cursor-pointer items-center justify-center rounded-full bg-[#dfeee3] px-1.5 font-mono text-[11px] font-medium text-[#2d4a35] ring-1 ring-[#9cc9a9]/40 transition-all hover:bg-[#c4e0cd] hover:ring-[#9cc9a9]"
+        className="mx-[2px] inline-flex h-[18px] w-[18px] -translate-y-[1px] cursor-pointer items-center justify-center rounded-full bg-[#dfeee3] font-mono text-[10px] font-medium text-[#2d4a35] ring-1 ring-[#9cc9a9]/40 transition-all hover:bg-[#c4e0cd] hover:ring-[#9cc9a9]"
       >
         {n}
       </button>

--- a/app/_components/question-card.tsx
+++ b/app/_components/question-card.tsx
@@ -27,7 +27,7 @@ export function QuestionCard({
         </label>
         <span className="text-[11px] text-[#8a968f]">Press ⌘↵ to submit</span>
       </div>
-      <div className="mt-3 flex items-end gap-3">
+      <div className="mt-3 flex items-center gap-3">
         <div className="relative flex-1">
           <textarea
             id="question-input"
@@ -36,9 +36,9 @@ export function QuestionCard({
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={onKeyDown}
             disabled={loading}
-            rows={2}
+            rows={1}
             placeholder="e.g. What are baseline requirements for cyber incident detection?"
-            className="min-h-[56px] w-full resize-none rounded-xl border border-[#2d4a35]/10 bg-white px-4 py-3 text-[15px] leading-relaxed text-[#1f2a23] placeholder-[#a0a9a4] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.8),0_1px_0_0_rgba(45,74,53,0.04)] focus:border-[#6ea580] focus:outline-none focus:ring-2 focus:ring-[#9cc9a9]/40 disabled:cursor-not-allowed disabled:opacity-60"
+            className="h-10 w-full resize-none rounded-xl border border-[#2d4a35]/10 bg-white px-4 py-0 text-[15px] leading-[2.5rem] text-[#1f2a23] placeholder-[#a0a9a4] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.8),0_1px_0_0_rgba(45,74,53,0.04)] focus:border-[#6ea580] focus:outline-none focus:ring-2 focus:ring-[#9cc9a9]/40 disabled:cursor-not-allowed disabled:opacity-60"
           />
         </div>
         <button
@@ -46,7 +46,7 @@ export function QuestionCard({
           onClick={onSubmit}
           disabled={disabled}
           aria-label={loading ? "Thinking" : "Ask"}
-          className="group relative self-stretch overflow-hidden rounded-xl bg-[#2d4a35] px-5 py-3 text-[13px] font-medium text-white shadow-[0_2px_8px_-2px_rgba(45,74,53,0.35)] transition-all hover:bg-[#1f3526] hover:shadow-[0_4px_14px_-2px_rgba(45,74,53,0.45)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-[#2d4a35]"
+          className="group relative h-10 shrink-0 overflow-hidden rounded-xl bg-[#2d4a35] px-5 text-[13px] font-medium text-white shadow-[0_2px_8px_-2px_rgba(45,74,53,0.35)] transition-all hover:bg-[#1f3526] hover:shadow-[0_4px_14px_-2px_rgba(45,74,53,0.45)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-[#2d4a35]"
         >
           <span className="relative flex items-center gap-2">
             {loading ? (


### PR DESCRIPTION
Closes #53, #54, #55

## Changes

**#53 — Input/button height**
- Both set to `h-10` (40px) for an exact match at conventional form size
- Textarea reduced to `rows={1}`, `py-0`, `leading-[2.5rem]` for single-line vertical centering
- Button changed from `self-stretch py-3` to explicit `h-10 shrink-0`

**#54 — Citation number badges**
- Fixed equal `w-[18px] h-[18px]` — perfect circle regardless of digit count
- Removed `min-w` and `px-1.5` which were causing oval distortion
- Font reduced from `text-[11px]` to `text-[10px]`

**#55 — Confidence badge tooltip**
- Hover tooltip appears below the badge explaining the scoring thresholds
- Copy: "Based on the semantic similarity score of the best-matching source… High ≥ 0.8, Medium ≥ 0.55, Low < 0.55"
- Pure CSS via Tailwind `group`/`group-hover` — no extra state or JS needed