### PR TITLE
History page: list past Q&As with date/time and citations

### DIFF
--- a/app/Pages/DashboardPage.tsx
+++ b/app/Pages/DashboardPage.tsx
@@ -15,6 +15,7 @@ import { AnswerCard } from "../_components/answer-card";
 import { TraceSection } from "../_components/trace-section";
 import { CitationsPanel } from "../_components/citations-panel";
 import type { RunMeta } from "../_components/shared";
+import { appendHistory } from "../_components/history-store";
 
 export function DashboardPage(): React.JSX.Element {
   const [query, setQuery] = useState("");
@@ -54,6 +55,11 @@ export function DashboardPage(): React.JSX.Element {
         return;
       }
       setResult(data as QueryResponse);
+      appendHistory({
+        askedAt: startedAtIso,
+        query: askedQuery,
+        response: data as QueryResponse,
+      });
       setSubmittedQuery(askedQuery);
       setRunMeta({
         run: shortHex(),

--- a/app/Pages/HistoryPage.tsx
+++ b/app/Pages/HistoryPage.tsx
@@ -1,7 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
 import { Card } from "../_components/card";
-import { SERIF } from "../_components/shared";
+import { SERIF, confidenceTier } from "../_components/shared";
+import { AnswerCard } from "../_components/answer-card";
+import {
+  loadHistory,
+  type HistoryEntry,
+} from "../_components/history-store";
 
 export function HistoryPage(): React.JSX.Element {
+  const [entries, setEntries] = useState<readonly HistoryEntry[]>([]);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    // Read from localStorage once on mount. We keep this inside useEffect
+    // (rather than useState initializer) to avoid SSR/hydration mismatch:
+    // server renders the empty-state, client swaps in real history after
+    // hydration. One-shot hydration read of a client-only external source
+    // (localStorage); not a candidate for the subscribe-and-setState
+    // pattern react-hooks/set-state-in-effect is designed to enforce.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setEntries(loadHistory());
+    setHydrated(true);
+  }, []);
+
   return (
     <main className="relative mx-auto w-full max-w-[1360px] flex-1 px-8 pb-24 pt-4">
       <div className="mb-6">
@@ -15,11 +39,65 @@ export function HistoryPage(): React.JSX.Element {
           Recently asked questions, answers, and the runs behind them.
         </p>
       </div>
-      <Card className="p-8">
-        <p className="text-[13px] text-[#6b7a70]">
-          Query history coming soon.
-        </p>
-      </Card>
+
+      {hydrated && entries.length === 0 && (
+        <Card className="p-8">
+          <p className="text-[13px] text-[#6b7a70]">
+            No questions asked yet. Head to the{" "}
+            <Link
+              href="/"
+              className="text-[#2d4a35] underline underline-offset-2 hover:text-[#1f3526]"
+            >
+              Dashboard
+            </Link>{" "}
+            to start.
+          </p>
+        </Card>
+      )}
+
+      {entries.length > 0 && (
+        <div className="space-y-6">
+          {entries.map((entry) => (
+            <HistoryItem key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
     </main>
   );
+}
+
+function HistoryItem({ entry }: { entry: HistoryEntry }): React.JSX.Element {
+  const tier = confidenceTier(entry.response.retrievals);
+  const formattedDate = formatAskedAt(entry.askedAt);
+  return (
+    <div className="space-y-3">
+      <Card className="p-6">
+        <div className="text-[11px] uppercase tracking-[0.18em] text-[#6b7a70]">
+          {formattedDate}
+        </div>
+        <p
+          className="mt-3 text-[18px] leading-[1.5] text-[#1f2a23]"
+          style={SERIF}
+        >
+          {entry.query}
+        </p>
+      </Card>
+      <AnswerCard
+        answer={entry.response.answer}
+        citations={entry.response.citations}
+        retrievals={entry.response.retrievals}
+        tier={tier}
+        onCitationClick={undefined}
+      />
+    </div>
+  );
+}
+
+function formatAskedAt(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
 }

--- a/app/_components/history-store.ts
+++ b/app/_components/history-store.ts
@@ -1,0 +1,86 @@
+import type { QueryResponse } from "../../shared/types";
+
+// ── constants ─────────────────────────────────────────────────────────────
+
+const STORAGE_KEY = "cc:history:v1";
+const MAX_ENTRIES = 50;
+
+// ── types ─────────────────────────────────────────────────────────────────
+
+export interface HistoryEntry {
+  readonly id: string;
+  readonly askedAt: string;
+  readonly query: string;
+  readonly response: QueryResponse;
+}
+
+// ── internals ─────────────────────────────────────────────────────────────
+
+function hasLocalStorage(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.localStorage !== "undefined"
+  );
+}
+
+function readRaw(): HistoryEntry[] {
+  if (!hasLocalStorage()) return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed as HistoryEntry[];
+  } catch {
+    return [];
+  }
+}
+
+function writeRaw(entries: readonly HistoryEntry[]): void {
+  if (!hasLocalStorage()) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // swallow quota / serialization errors — history is best-effort
+  }
+}
+
+function makeId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID.
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+// ── public API ────────────────────────────────────────────────────────────
+
+export function loadHistory(): HistoryEntry[] {
+  return readRaw();
+}
+
+export function appendHistory(entry: Omit<HistoryEntry, "id">): void {
+  if (!hasLocalStorage()) return;
+  const existing = readRaw();
+  const mostRecent = existing[0];
+  if (mostRecent && mostRecent.query.trim() === entry.query.trim()) {
+    return;
+  }
+  const next: HistoryEntry[] = [
+    { ...entry, id: makeId() },
+    ...existing,
+  ].slice(0, MAX_ENTRIES);
+  writeRaw(next);
+}
+
+export function clearHistory(): void {
+  if (!hasLocalStorage()) return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // swallow
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the `/history` stub with a real, client-side history list: each entry shows a formatted date/time, the question in the dashboard's serif style, and the full answer (with inline citation chips + sources row) rendered via the existing `AnswerCard`.
- Adds `app/_components/history-store.ts` — a thin `localStorage`-backed store (`cc:history:v1`) with `loadHistory` / `appendHistory` / `clearHistory`. Prepends on append, dedups back-to-back identical queries, caps at 50 entries, and is SSR-safe (all `localStorage` access guarded by `typeof window` checks).
- Hooks `DashboardPage` to append on any successful `/api/query` 200 response.

No backend, no API route, no new deps. Non-goals (from the spec): search, pagination, re-run/delete UI, export, trace section, right-side citations panel drawer.

Closes #57

## Test plan

- [ ] `pnpm dev` → ask a question on `/`, confirm `/history` shows it with date/time + inline citation chips + sources row
- [ ] Ask a few more questions; confirm newest-first ordering
- [ ] Reload the page; confirm history persists
- [ ] Clear localStorage (or open in a fresh browser); confirm empty-state Card with inline Dashboard link
- [ ] Ask the same question twice in a row; confirm only one history entry
- [ ] `pnpm typecheck` and `pnpm lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)