### PR TITLE
Answer eval: run items in parallel

### DIFF
--- a/app/_components/answer-evaluation.tsx
+++ b/app/_components/answer-evaluation.tsx
@@ -44,8 +44,13 @@ export function AnswerEvaluation(): React.JSX.Element {
           return;
         }
         const item = record as unknown as AnswerStreamItem;
-        if (typeof item.index === "number" && typeof item.total === "number") {
-          setProgress({ index: item.index, total: item.total });
+        if (typeof item.total === "number") {
+          // Server fires items in parallel, so item.index arrives out of
+          // order. Count completions locally for a monotonic counter.
+          setProgress((prev) => ({
+            index: (prev?.index ?? 0) + 1,
+            total: item.total,
+          }));
         }
       });
     } catch (err) {

--- a/app/api/evaluations/answer/route.ts
+++ b/app/api/evaluations/answer/route.ts
@@ -8,8 +8,8 @@ import {
 } from "../../../../eval/core";
 
 export const runtime = "nodejs";
-// Judge is a model call per item × 30 items — leave a 5-minute budget and
-// rely on NDJSON streaming to keep the connection warm.
+// Items run in parallel (see POST), but keep a 5-minute budget as a
+// safety cap for the slowest item and network hiccups.
 export const maxDuration = 300;
 
 /**
@@ -60,41 +60,44 @@ export async function POST(): Promise<Response> {
       }> = [];
 
       try {
-        for (let i = 0; i < loadedItems.length; i++) {
-          const item = loadedItems[i];
-
-          // Production answer via compiled graph
-          const state = await graph.invoke({ query: item.query });
-          const answer = state.answer ?? "";
-
-          try {
-            const judge = await judgeAnswer(client, item, answer);
-            perItem.push({
-              category: item.category,
-              accuracy: judge.accuracy,
-              completeness: judge.completeness,
-              relevance: judge.relevance,
-            });
-            write({
-              index: i + 1,
-              total,
-              query: item.query,
-              category: item.category,
-              accuracy: judge.accuracy,
-              completeness: judge.completeness,
-              relevance: judge.relevance,
-              feedback: judge.feedback,
-            });
-          } catch (err) {
-            write({
-              index: i + 1,
-              total,
-              query: item.query,
-              category: item.category,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          }
-        }
+        // Run generate + judge for every item concurrently. Each item is
+        // 2 OpenAI calls (graph generate + judge) — for a 30-item benchmark
+        // that's ~60 calls, well under any tier's RPM and handled by the
+        // Node SDK's built-in 429 retries. This cuts wall-clock from
+        // ~sequential sum-of-latencies down to ~max-of-latencies.
+        await Promise.all(
+          loadedItems.map(async (item, i) => {
+            try {
+              const state = await graph.invoke({ query: item.query });
+              const answer = state.answer ?? "";
+              const judge = await judgeAnswer(client, item, answer);
+              perItem.push({
+                category: item.category,
+                accuracy: judge.accuracy,
+                completeness: judge.completeness,
+                relevance: judge.relevance,
+              });
+              write({
+                index: i + 1,
+                total,
+                query: item.query,
+                category: item.category,
+                accuracy: judge.accuracy,
+                completeness: judge.completeness,
+                relevance: judge.relevance,
+                feedback: judge.feedback,
+              });
+            } catch (err) {
+              write({
+                index: i + 1,
+                total,
+                query: item.query,
+                category: item.category,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }),
+        );
 
         const avg = (xs: number[]) =>
           xs.length === 0 ? 0 : xs.reduce((s, x) => s + x, 0) / xs.length;


### PR DESCRIPTION
## Summary
- `app/api/evaluations/answer/route.ts` now runs `graph.invoke` + `judgeAnswer` for every benchmark item concurrently via `Promise.all`, mirroring the pattern already used by the retrieval route. The per-item try/catch still streams `{ error }` lines so the UI can show partial progress.
- `app/_components/answer-evaluation.tsx` counts completions locally instead of trusting `item.index`, because items now stream out of order (same pattern the retrieval UI uses).
- Updated the `maxDuration` comment to match the new flow (the 5-minute cap is now a safety ceiling, not a budget sized for 30 sequential model calls).

## API restrictions checked
- OpenAI rate limits are **RPM / TPM / RPD / TPD**, not concurrent-connection limits. For a 30-item benchmark we issue ~60 calls (generate via `gpt-4o-mini`, judge via `gpt-4.1-nano`), which is well below any tier's RPM.
- The Node SDK retries 429 / 408 / 409 / 5xx / network errors with short exponential backoff (`maxRetries: 2` by default), so transient rate pressure is handled automatically.
- Pinecone `searchRecords` is not the bottleneck; the retrieval route already parallelizes 30 of these without issue.

## Test plan
- [ ] `pnpm typecheck` passes (verified).
- [ ] Open `/evaluations`, click "Run evaluation" on the Answer card, and confirm: progress counter increments monotonically 1→30; all three summary cards + category bar chart render; wall-clock drops from sequential-sum-of-latencies to roughly the slowest single item.
- [ ] Intentionally kill one benchmark query (or observe an error) and confirm the per-item error line still surfaces without aborting the rest of the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)