### PR TITLE
Library page: grid of corpus docs + detail view

### DIFF
--- a/app/Pages/LibraryDetailPage.tsx
+++ b/app/Pages/LibraryDetailPage.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import { Card } from "../_components/card";
+import { Markdown } from "../_components/markdown";
+import { SERIF, authorityStyle, type Authority } from "../_components/shared";
+import type { CorpusDoc } from "../_lib/corpus";
+
+function isExternalUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+export function LibraryDetailPage({
+  doc,
+}: {
+  doc: CorpusDoc;
+}): React.JSX.Element {
+  const style = authorityStyle(doc.authority as Authority);
+
+  return (
+    <main className="relative mx-auto w-full max-w-[1360px] flex-1 px-8 pb-24 pt-4">
+      <div className="mb-6">
+        <Link
+          href="/library"
+          aria-label="Back to Library"
+          className="inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-2 text-[11px] font-medium text-[#2d4a35] ring-1 ring-[#9cc9a9]/40 backdrop-blur-md transition-colors hover:bg-white"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path
+              d="M7.5 3L4.5 6L7.5 9"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          Library
+        </Link>
+      </div>
+
+      <div className="mb-6">
+        <h1
+          className="text-[28px] leading-tight tracking-tight text-[#1f2a23]"
+          style={SERIF}
+        >
+          {doc.title}
+        </h1>
+        <div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-[#6b7a70]">
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-[2px] text-[10px] font-medium tracking-wide ${style.chip}`}
+          >
+            {style.label}
+          </span>
+          <span aria-hidden>·</span>
+          <span>{doc.citationIdDisplay}</span>
+          {doc.docType && (
+            <>
+              <span aria-hidden>·</span>
+              <span>{doc.docType}</span>
+            </>
+          )}
+          {doc.effectiveDate && (
+            <>
+              <span aria-hidden>·</span>
+              <span>{doc.effectiveDate}</span>
+            </>
+          )}
+          {isExternalUrl(doc.sourceUrl) && (
+            <>
+              <span aria-hidden>·</span>
+              <a
+                href={doc.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#2d4a35] underline underline-offset-2 hover:text-[#1f2a23]"
+              >
+                Source
+              </a>
+            </>
+          )}
+        </div>
+      </div>
+
+      <Card className="p-8">
+        <div className="mx-auto max-w-[720px]">
+          <Markdown source={doc.body} />
+        </div>
+      </Card>
+    </main>
+  );
+}

--- a/app/Pages/LibraryPage.tsx
+++ b/app/Pages/LibraryPage.tsx
@@ -1,7 +1,10 @@
-import { Card } from "../_components/card";
 import { SERIF } from "../_components/shared";
+import { LibraryCard } from "../_components/library-card";
+import { loadCorpusDocs } from "../_lib/corpus";
 
 export function LibraryPage(): React.JSX.Element {
+  const docs = loadCorpusDocs();
+
   return (
     <main className="relative mx-auto w-full max-w-[1360px] flex-1 px-8 pb-24 pt-4">
       <div className="mb-6">
@@ -15,11 +18,12 @@ export function LibraryPage(): React.JSX.Element {
           Indexed sources, authorities, and document versions.
         </p>
       </div>
-      <Card className="p-8">
-        <p className="text-[13px] text-[#6b7a70]">
-          Source library coming soon.
-        </p>
-      </Card>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {docs.map((doc) => (
+          <LibraryCard key={doc.slug} doc={doc} />
+        ))}
+      </div>
     </main>
   );
 }

--- a/app/_components/library-card.tsx
+++ b/app/_components/library-card.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { Card } from "./card";
+import { SERIF, authorityStyle, type Authority } from "./shared";
+import type { CorpusDoc } from "../_lib/corpus";
+
+const SNIPPET_MAX_CHARS = 180;
+
+function snippetFromBody(body: string): string {
+  // Strip leading heading markers and collapse whitespace so the snippet
+  // reads like prose regardless of where the body starts.
+  const cleaned = body
+    .replace(/^\s*#{1,6}\s+.*$/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (cleaned.length <= SNIPPET_MAX_CHARS) return cleaned;
+  return cleaned.slice(0, SNIPPET_MAX_CHARS).trimEnd() + "…";
+}
+
+export function LibraryCard({ doc }: { doc: CorpusDoc }): React.JSX.Element {
+  const style = authorityStyle(doc.authority as Authority);
+  const snippet = snippetFromBody(doc.body);
+  const footerDate = doc.effectiveDate;
+  const footerType = doc.docType;
+
+  return (
+    <Link
+      href={`/library/${doc.slug}`}
+      className="group block focus:outline-none focus-visible:ring-2 focus-visible:ring-[#9cc9a9] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent rounded-2xl"
+    >
+      <Card className="flex h-full flex-col p-5 transition-colors group-hover:bg-white/90">
+        <div className="flex items-start justify-between gap-3">
+          <span
+            className="text-[10px] uppercase tracking-[0.18em] text-[#6b7a70]"
+          >
+            {doc.citationIdDisplay}
+          </span>
+          <span
+            className={`inline-flex shrink-0 items-center rounded-full px-2 py-[2px] text-[10px] font-medium tracking-wide ${style.chip}`}
+          >
+            {style.label}
+          </span>
+        </div>
+
+        <h2
+          className="mt-2 line-clamp-2 text-[16px] leading-snug tracking-tight text-[#1f2a23]"
+          style={SERIF}
+        >
+          {doc.title}
+        </h2>
+
+        <p className="mt-3 flex-1 text-[12.5px] leading-[1.55] text-[#435048]">
+          {snippet}
+        </p>
+
+        <div className="mt-4 flex items-center gap-2 text-[11px] text-[#6b7a70]">
+          {footerType && <span>{footerType}</span>}
+          {footerType && footerDate && <span aria-hidden>·</span>}
+          {footerDate && <span>{footerDate}</span>}
+        </div>
+      </Card>
+    </Link>
+  );
+}

--- a/app/_components/markdown.tsx
+++ b/app/_components/markdown.tsx
@@ -1,0 +1,64 @@
+import { SERIF } from "./shared";
+
+/**
+ * Minimal server-side markdown renderer.
+ *
+ * The corpus body is mostly prose with occasional headings. Rather than
+ * pulling in `react-markdown` and its plugin chain, we split on blank lines
+ * and match headings at the block start. Anything else is emitted as a
+ * paragraph preserving whitespace. Bullets, bold, italics, and inline links
+ * render as literal text — acceptable for this browse surface.
+ */
+export function Markdown({ source }: { source: string }): React.JSX.Element {
+  const blocks = source.split(/\n\s*\n/).map((b) => b.replace(/^\n+|\n+$/g, ""));
+
+  return (
+    <div className="space-y-4">
+      {blocks.map((block, i) => {
+        if (block.length === 0) return null;
+
+        if (block.startsWith("# ")) {
+          return (
+            <h1
+              key={i}
+              className="mt-2 text-[26px] leading-tight tracking-tight text-[#1f2a23]"
+              style={SERIF}
+            >
+              {block.slice(2)}
+            </h1>
+          );
+        }
+        if (block.startsWith("## ")) {
+          return (
+            <h2
+              key={i}
+              className="mb-2 mt-6 text-[20px] leading-tight tracking-tight text-[#1f2a23]"
+              style={SERIF}
+            >
+              {block.slice(3)}
+            </h2>
+          );
+        }
+        if (block.startsWith("### ")) {
+          return (
+            <h3
+              key={i}
+              className="mb-2 mt-6 text-[13px] font-semibold tracking-wide text-[#2d4a35]"
+            >
+              {block.slice(4)}
+            </h3>
+          );
+        }
+
+        return (
+          <p
+            key={i}
+            className="whitespace-pre-wrap text-[14.5px] leading-[1.75] text-[#26302a]"
+          >
+            {block}
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/_lib/corpus.ts
+++ b/app/_lib/corpus.ts
@@ -1,0 +1,97 @@
+/**
+ * Server-side corpus loader.
+ *
+ * Reads the `corpus/*.md` files synchronously and exposes a small typed API
+ * that both `/library` and `/library/[slug]` server components consume.
+ *
+ * Parses front-matter with `gray-matter` (already a dependency for the
+ * ingester). Mirrors the ingester's `README.md` / `ARCHITECTURE.md` skip
+ * rule. Skips any file missing required v2 front-matter fields rather than
+ * throwing — missing metadata should hide a doc from the browse surface but
+ * not crash the page.
+ */
+
+import { readFileSync, readdirSync } from "fs";
+import { join, resolve } from "path";
+import matter from "gray-matter";
+
+export interface CorpusDoc {
+  readonly slug: string;
+  readonly title: string;
+  readonly authority: string;
+  readonly source: string;
+  readonly citationIdDisplay: string;
+  readonly effectiveDate: string;
+  readonly sourceUrl: string;
+  readonly docType: string;
+  readonly versionStatus: string;
+  readonly body: string;
+}
+
+const REQUIRED_FIELDS = [
+  "title",
+  "citation_id_display",
+  "authority",
+  "source",
+  "effective_date",
+  "source_url",
+] as const;
+
+function corpusDir(): string {
+  return resolve(process.cwd(), "corpus");
+}
+
+function parseFile(slug: string, filePath: string): CorpusDoc | null {
+  const raw = readFileSync(filePath, "utf8");
+  const { data, content } = matter(raw);
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!data[field]) return null;
+  }
+
+  return {
+    slug,
+    title: String(data["title"]),
+    authority: String(data["authority"]),
+    source: String(data["source"]),
+    citationIdDisplay: String(data["citation_id_display"]),
+    effectiveDate: String(data["effective_date"]),
+    sourceUrl: String(data["source_url"]),
+    docType: String(data["doc_type"] ?? ""),
+    versionStatus: String(data["version_status"] ?? "current"),
+    body: content,
+  };
+}
+
+export function loadCorpusDocs(): readonly CorpusDoc[] {
+  const dir = corpusDir();
+  const files = readdirSync(dir).filter(
+    (f) => f.endsWith(".md") && f !== "README.md" && f !== "ARCHITECTURE.md",
+  );
+
+  const docs: CorpusDoc[] = [];
+  for (const fileName of files) {
+    const slug = fileName.slice(0, -".md".length);
+    const doc = parseFile(slug, join(dir, fileName));
+    if (doc) docs.push(doc);
+  }
+
+  docs.sort((a, b) =>
+    a.title.toLowerCase().localeCompare(b.title.toLowerCase()),
+  );
+  return docs;
+}
+
+export function loadCorpusDoc(slug: string): CorpusDoc | null {
+  // Defensive slug validation: slugs must match the kebab-case filenames on
+  // disk. Reject anything that could escape the corpus directory.
+  if (!/^[a-zA-Z0-9._-]+$/.test(slug)) return null;
+  if (slug === "README" || slug === "ARCHITECTURE") return null;
+
+  const filePath = join(corpusDir(), `${slug}.md`);
+  try {
+    return parseFile(slug, filePath);
+  } catch {
+    return null;
+  }
+}

--- a/app/library/[slug]/page.tsx
+++ b/app/library/[slug]/page.tsx
@@ -1,0 +1,14 @@
+import { notFound } from "next/navigation";
+import { LibraryDetailPage } from "../../Pages/LibraryDetailPage";
+import { loadCorpusDoc } from "../../_lib/corpus";
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<React.JSX.Element> {
+  const { slug } = await params;
+  const doc = loadCorpusDoc(slug);
+  if (!doc) notFound();
+  return <LibraryDetailPage doc={doc} />;
+}


### PR DESCRIPTION
## Summary

- `/library` is now a grid of cards — one per corpus doc — sorted alphabetically by title. Each card shows title, authority pill, `citation_id_display`, a ~180-char snippet, and `docType · effectiveDate`.
- `/library/[slug]` renders the full document body with a `← Library` back button at the top, meta row (authority · citation_id · doc_type · effective_date · optional external source link), and a minimal in-house markdown renderer (headings + paragraphs). Bogus slugs return 404 via `notFound()`.
- Adds a shared server-side loader at `app/_lib/corpus.ts` using the same `gray-matter` parsing the ingester uses. `README.md` and `ARCHITECTURE.md` are excluded. Zero new dependencies.

All rendering is server-side; no API route, no client fetch.

Closes #59

## Test plan

- [ ] `pnpm dev` → `/library` renders a grid of ~37 cards, alphabetically ordered
- [ ] Click a card → navigates to `/library/<slug>` with back button visible
- [ ] Back button returns to `/library`
- [ ] External `source_url` (http/https) renders as a "Source" link; `internal://` URLs are omitted
- [ ] Hit `/library/bogus-slug` → Next.js 404
- [ ] `pnpm typecheck` and `pnpm lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)