### PR TITLE
History page: visually chunk each Q&A pair

### DIFF
--- a/app/Pages/HistoryPage.tsx
+++ b/app/Pages/HistoryPage.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import Link from "next/link";
 import { Card } from "../_components/card";
-import { SERIF, confidenceTier } from "../_components/shared";
-import { AnswerCard } from "../_components/answer-card";
+import { SERIF } from "../_components/shared";
+import { HistoryChunk } from "../_components/history-chunk";
 import {
   loadHistory,
   type HistoryEntry,
@@ -56,48 +56,20 @@ export function HistoryPage(): React.JSX.Element {
       )}
 
       {entries.length > 0 && (
-        <div className="space-y-6">
-          {entries.map((entry) => (
-            <HistoryItem key={entry.id} entry={entry} />
+        <div>
+          {entries.map((entry, index) => (
+            <Fragment key={entry.id}>
+              {index > 0 && (
+                <hr
+                  className="my-10 border-t border-[#2d4a35]/10 md:my-12"
+                  aria-hidden
+                />
+              )}
+              <HistoryChunk entry={entry} />
+            </Fragment>
           ))}
         </div>
       )}
     </main>
   );
-}
-
-function HistoryItem({ entry }: { entry: HistoryEntry }): React.JSX.Element {
-  const tier = confidenceTier(entry.response.retrievals);
-  const formattedDate = formatAskedAt(entry.askedAt);
-  return (
-    <div className="space-y-3">
-      <Card className="p-6">
-        <div className="text-[11px] uppercase tracking-[0.18em] text-[#6b7a70]">
-          {formattedDate}
-        </div>
-        <p
-          className="mt-3 text-[18px] leading-[1.5] text-[#1f2a23]"
-          style={SERIF}
-        >
-          {entry.query}
-        </p>
-      </Card>
-      <AnswerCard
-        answer={entry.response.answer}
-        citations={entry.response.citations}
-        retrievals={entry.response.retrievals}
-        tier={tier}
-        onCitationClick={undefined}
-      />
-    </div>
-  );
-}
-
-function formatAskedAt(iso: string): string {
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return iso;
-  return date.toLocaleString(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  });
 }

--- a/app/_components/history-chunk.tsx
+++ b/app/_components/history-chunk.tsx
@@ -1,0 +1,44 @@
+import { Card } from "./card";
+import { SERIF, confidenceTier } from "./shared";
+import { AnswerCard } from "./answer-card";
+import type { HistoryEntry } from "./history-store";
+
+export function HistoryChunk({
+  entry,
+}: {
+  entry: HistoryEntry;
+}): React.JSX.Element {
+  const tier = confidenceTier(entry.response.retrievals);
+  const formattedDate = formatAskedAt(entry.askedAt);
+  return (
+    <article className="space-y-3">
+      <Card className="p-6">
+        <div className="text-[11px] uppercase tracking-[0.18em] text-[#6b7a70]">
+          {formattedDate}
+        </div>
+        <p
+          className="mt-3 text-[18px] leading-[1.5] text-[#1f2a23]"
+          style={SERIF}
+        >
+          {entry.query}
+        </p>
+      </Card>
+      <AnswerCard
+        answer={entry.response.answer}
+        citations={entry.response.citations}
+        retrievals={entry.response.retrievals}
+        tier={tier}
+        onCitationClick={undefined}
+      />
+    </article>
+  );
+}
+
+function formatAskedAt(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}


### PR DESCRIPTION
## Summary

- Extracts `HistoryItem` into its own `HistoryChunk` component (`app/_components/history-chunk.tsx`) and wraps each question + answer pair in an `<article>` with tight `space-y-3` internal grouping.
- Replaces the flat `space-y-6` list on `/history` with explicit `<hr className="my-10 border-t border-[#2d4a35]/10 md:my-12" />` dividers between entries, so inter-entry spacing (40–48px + rule) is visibly larger than the 12px internal grouping.
- Reuses only existing tokens (`#2d4a35/10`). Empty-state is untouched.

Closes #63

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Manual check at `/history` with ≥2 entries (recommended before merge)

[REVIEWER AGENT] APPROVED

https://claude.ai/code/session_01G5sLhGrMqAm2kW8PQiMp7x