### PR TITLE
Evaluations: add `?` tooltip explaining each metric

### DIFF
--- a/app/_components/answer-evaluation.tsx
+++ b/app/_components/answer-evaluation.tsx
@@ -81,18 +81,21 @@ export function AnswerEvaluation(): React.JSX.Element {
               tier={tierForJudge(summary.accuracy)}
               format="judge"
               hint={`Across ${summary.total} items`}
+              explanation="How factually correct the answer is, judged by an LLM on a 1–5 scale. Higher is better."
             />
             <MetricCard
               label="Completeness"
               value={summary.completeness}
               tier={tierForJudge(summary.completeness)}
               format="judge"
+              explanation="How thoroughly the answer covers what was asked, judged by an LLM on a 1–5 scale."
             />
             <MetricCard
               label="Relevance"
               value={summary.relevance}
               tier={tierForJudge(summary.relevance)}
               format="judge"
+              explanation="How closely the answer sticks to the question, judged by an LLM on a 1–5 scale."
             />
           </div>
           <CategoryBarChart

--- a/app/_components/metric-card.tsx
+++ b/app/_components/metric-card.tsx
@@ -5,11 +5,15 @@ import {
   type MetricFormat,
   type ThresholdTier,
 } from "./evaluation-types";
+import { MetricTooltip } from "./metric-tooltip";
 
 /**
  * Large metric card used in the /evaluations dashboard. Each card shows a
  * small label, a big numeric value (formatted per the metric type) and a
  * soft coloured left strip reflecting the green/amber/red threshold tier.
+ *
+ * When an `explanation` is supplied, a small `?` affordance is rendered next
+ * to the label that reveals a plain-language explanation on hover or focus.
  */
 export function MetricCard({
   label,
@@ -17,12 +21,14 @@ export function MetricCard({
   tier,
   format,
   hint,
+  explanation,
 }: {
   label: string;
   value: number;
   tier: ThresholdTier;
   format: MetricFormat;
   hint?: string;
+  explanation?: string;
 }): React.JSX.Element {
   const palette = paletteForTier(tier);
   return (
@@ -32,8 +38,11 @@ export function MetricCard({
         className={`absolute left-0 top-0 h-full w-1.5 ${palette.strip}`}
       />
       <div className="pl-3">
-        <div className="text-[11px] uppercase tracking-[0.18em] text-[#6b7a70]">
-          {label}
+        <div className="flex items-center gap-1.5 text-[11px] uppercase tracking-[0.18em] text-[#6b7a70]">
+          <span>{label}</span>
+          {explanation && (
+            <MetricTooltip label={label} explanation={explanation} />
+          )}
         </div>
         <div className={`mt-2 text-[32px] font-light leading-none ${palette.value}`}>
           {formatMetric(value, format)}

--- a/app/_components/metric-tooltip.tsx
+++ b/app/_components/metric-tooltip.tsx
@@ -1,0 +1,42 @@
+/**
+ * Small `?` affordance that reveals a dark tooltip popover on hover or
+ * keyboard focus. Visual treatment mirrors the tooltip used by the
+ * `ConfidenceBadge` in `answer-card.tsx`.
+ *
+ * The trigger is a real `<button>` so it is focusable via keyboard and
+ * announces an accessible name ("Explain <metric>"). The popover carries
+ * `role="tooltip"` and is revealed via `group-hover` / `group-focus-within`
+ * so it dismisses automatically on blur or mouse-leave.
+ */
+export function MetricTooltip({
+  label,
+  explanation,
+}: {
+  label: string;
+  explanation: string;
+}): React.JSX.Element {
+  return (
+    <span className="group relative inline-flex">
+      <button
+        type="button"
+        aria-label={`Explain ${label}`}
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-[#e5ebe7] text-[10px] font-medium leading-none text-[#6b7a70] ring-1 ring-[#d4dcd7] transition-colors hover:bg-[#d4dcd7] hover:text-[#26302a] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6b7a70]"
+      >
+        ?
+      </button>
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute left-0 top-full z-50 mt-2 w-60 rounded-xl bg-[#1f2a23] px-3.5 py-2.5 text-[12px] font-normal normal-case leading-relaxed tracking-normal text-white/90 opacity-0 shadow-[0_8px_24px_-4px_rgba(31,42,35,0.4)] transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
+      >
+        <span className="mb-1 block text-[9px] uppercase tracking-[0.18em] text-white/50">
+          {label}
+        </span>
+        {explanation}
+        <span
+          aria-hidden
+          className="absolute left-4 top-0 -translate-y-full border-4 border-transparent border-b-[#1f2a23]"
+        />
+      </span>
+    </span>
+  );
+}

--- a/app/_components/retrieval-evaluation.tsx
+++ b/app/_components/retrieval-evaluation.tsx
@@ -76,18 +76,21 @@ export function RetrievalEvaluation(): React.JSX.Element {
               tier={tierForRatio(summary.mrr)}
               format="ratio"
               hint={`Across ${summary.total} items`}
+              explanation="How high up the correct source appears in the search results, on average. Scored 0–1 — higher is better. 1.0 means the right source is always first."
             />
             <MetricCard
               label="nDCG"
               value={summary.ndcg}
               tier={tierForRatio(summary.ndcg)}
               format="ratio"
+              explanation="How well the search ranks the most relevant sources near the top. Scored 0–1 — higher is better."
             />
             <MetricCard
               label="Keyword coverage"
               value={summary.keywordCoverage}
               tier={tierForRatio(summary.keywordCoverage)}
               format="percent"
+              explanation="The share of expected keywords from the reference answer that appear in the retrieved sources. Scored 0–100%."
             />
           </div>
           <CategoryBarChart


### PR DESCRIPTION
## Summary

- Adds a new `MetricTooltip` (`app/_components/metric-tooltip.tsx`) — a focusable `?` button with `aria-label` and a `role="tooltip"` popover that mirrors the dark-popover treatment used in the confidence badge.
- `MetricCard` now accepts an optional `explanation?: string`; cards without it render unchanged.
- `RetrievalEvaluation` passes plain-English explanations for MRR, nDCG, and Keyword coverage. `AnswerEvaluation` does the same for Accuracy, Completeness, and Relevance.
- Reveal triggers: `group-hover` + `group-focus-within` so both mouse and keyboard work.

Closes #62

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Manual check at `/evaluations` — hover + Tab to each `?` affordance

[REVIEWER AGENT] APPROVED

https://claude.ai/code/session_01G5sLhGrMqAm2kW8PQiMp7x