### PR TITLE
Confidence badge: introduce green/yellow/orange color tokens

### DIFF
--- a/app/_components/answer-card.tsx
+++ b/app/_components/answer-card.tsx
@@ -2,13 +2,13 @@ import { useMemo } from "react";
 import type { Citation, Retrieval } from "../../shared/types";
 import { Card } from "./card";
 import {
-  SERIF,
   type ConfidenceTier,
   parseAnswerParts,
   findRetrievalForCitation,
   citationMarkerNumber,
 } from "./shared";
 import { CitationChip } from "./citation-chip";
+import { ConfidenceBadge } from "./confidence-badge";
 import { SourcesRow } from "./sources-row";
 
 export function AnswerCard({
@@ -80,86 +80,4 @@ export function AnswerCard({
   );
 }
 
-const CONFIDENCE_TOOLTIP =
-  "Based on the semantic similarity score of the best-matching source retrieved for your question. High = score ≥ 0.8, Medium = score ≥ 0.55, Low = score < 0.55.";
-
-function ConfidenceBadge({
-  tier,
-}: {
-  tier: ConfidenceTier;
-}): React.JSX.Element {
-  const isPeach = tier === "HIGH" || tier === "MEDIUM";
-  const label =
-    tier === "HIGH" ? "High" : tier === "MEDIUM" ? "Medium" : "Low";
-
-  const badge = isPeach ? (
-    <div className="flex items-center gap-3 rounded-2xl bg-[#fde4d4]/70 px-3.5 py-2 ring-1 ring-[#fab89a]/40">
-      <div className="flex flex-col items-end leading-none">
-        <span className="text-[9px] uppercase tracking-[0.2em] text-[#8b4a2f]">
-          Confidence
-        </span>
-        <span
-          className="mt-1 text-[18px] leading-none tracking-tight text-[#6b2d0e]"
-          style={SERIF}
-        >
-          {label}
-        </span>
-      </div>
-      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-white ring-1 ring-[#fab89a]/50">
-        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-          <path
-            d="M3.5 7L6 9.5L10.5 4.5"
-            stroke="#8b4a2f"
-            strokeWidth="1.6"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </div>
-    </div>
-  ) : (
-    <div className="flex items-center gap-3 rounded-2xl bg-[#dfeee3]/70 px-3.5 py-2 ring-1 ring-[#9cc9a9]/40">
-      <div className="flex flex-col items-end leading-none">
-        <span className="text-[9px] uppercase tracking-[0.2em] text-[#2d4a35]/70">
-          Confidence
-        </span>
-        <span
-          className="mt-1 text-[18px] leading-none tracking-tight text-[#2d4a35]"
-          style={SERIF}
-        >
-          {label}
-        </span>
-      </div>
-      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-white ring-1 ring-[#9cc9a9]/50">
-        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-          <path
-            d="M7 3.5V7.5M7 10V10.2"
-            stroke="#2d4a35"
-            strokeWidth="1.6"
-            strokeLinecap="round"
-          />
-        </svg>
-      </div>
-    </div>
-  );
-
-  return (
-    <div className="group relative">
-      {badge}
-      <div
-        role="tooltip"
-        className="pointer-events-none absolute right-0 top-full z-50 mt-2 w-60 rounded-xl bg-[#1f2a23] px-3.5 py-2.5 text-[12px] leading-relaxed text-white/90 opacity-0 shadow-[0_8px_24px_-4px_rgba(31,42,35,0.4)] transition-opacity duration-150 group-hover:opacity-100"
-      >
-        <span className="mb-1 block text-[9px] uppercase tracking-[0.18em] text-white/50">
-          How confidence is determined
-        </span>
-        {CONFIDENCE_TOOLTIP}
-        <span
-          aria-hidden
-          className="absolute right-4 top-0 -translate-y-full border-4 border-transparent border-b-[#1f2a23]"
-        />
-      </div>
-    </div>
-  );
-}
 

--- a/app/_components/confidence-badge.tsx
+++ b/app/_components/confidence-badge.tsx
@@ -1,0 +1,107 @@
+import { SERIF, CONFIDENCE_COLORS, type ConfidenceTier } from "./shared";
+
+const CONFIDENCE_TOOLTIP =
+  "Based on the semantic similarity score of the best-matching source retrieved for your question. High = score ≥ 0.8, Medium = score ≥ 0.55, Low = score < 0.55.";
+
+const TIER_LABEL: Record<ConfidenceTier, string> = {
+  HIGH: "High",
+  MEDIUM: "Medium",
+  LOW: "Low",
+};
+
+function TierIcon({
+  tier,
+  stroke,
+}: {
+  tier: ConfidenceTier;
+  stroke: string;
+}): React.JSX.Element {
+  if (tier === "HIGH") {
+    // Checkmark.
+    return (
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <path
+          d="M3.5 7L6 9.5L10.5 4.5"
+          stroke={stroke}
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    );
+  }
+  if (tier === "MEDIUM") {
+    // Info-style glyph: dot over a short vertical stroke.
+    return (
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <circle cx="7" cy="4" r="0.9" fill={stroke} />
+        <path
+          d="M7 6.5V10"
+          stroke={stroke}
+          strokeWidth="1.6"
+          strokeLinecap="round"
+        />
+      </svg>
+    );
+  }
+  // LOW — alert / exclamation glyph (reused from the previous sage branch).
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <path
+        d="M7 3.5V7.5M7 10V10.2"
+        stroke={stroke}
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function ConfidenceBadge({
+  tier,
+}: {
+  tier: ConfidenceTier;
+}): React.JSX.Element {
+  const color = CONFIDENCE_COLORS[tier];
+  const label = TIER_LABEL[tier];
+
+  return (
+    <div className="group relative">
+      <div
+        className={`flex items-center gap-3 rounded-2xl px-3.5 py-2 ring-1 ${color.bg} ${color.ring}`}
+      >
+        <div className="flex flex-col items-end leading-none">
+          <span
+            className={`text-[9px] uppercase tracking-[0.2em] ${color.text}`}
+          >
+            Confidence
+          </span>
+          <span
+            className={`mt-1 text-[18px] leading-none tracking-tight ${color.text}`}
+            style={SERIF}
+          >
+            {label}
+          </span>
+        </div>
+        <div
+          className={`flex h-7 w-7 items-center justify-center rounded-full bg-white ring-1 ${color.iconBg}`}
+        >
+          <TierIcon tier={tier} stroke={color.iconStroke} />
+        </div>
+      </div>
+      <div
+        role="tooltip"
+        className="pointer-events-none absolute right-0 top-full z-50 mt-2 w-60 rounded-xl bg-[#1f2a23] px-3.5 py-2.5 text-[12px] leading-relaxed text-white/90 opacity-0 shadow-[0_8px_24px_-4px_rgba(31,42,35,0.4)] transition-opacity duration-150 group-hover:opacity-100"
+      >
+        <span className="mb-1 block text-[9px] uppercase tracking-[0.18em] text-white/50">
+          How confidence is determined
+        </span>
+        {CONFIDENCE_TOOLTIP}
+        <span
+          aria-hidden
+          className="absolute right-4 top-0 -translate-y-full border-4 border-transparent border-b-[#1f2a23]"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/_components/shared.ts
+++ b/app/_components/shared.ts
@@ -76,6 +76,38 @@ export function confidenceTier(
   return "LOW";
 }
 
+export interface ConfidenceColor {
+  readonly bg: string;
+  readonly ring: string;
+  readonly text: string;
+  readonly iconBg: string;
+  readonly iconStroke: string;
+}
+
+export const CONFIDENCE_COLORS: Record<ConfidenceTier, ConfidenceColor> = {
+  HIGH: {
+    bg: "bg-[#dfeee3]/70",
+    ring: "ring-[#9cc9a9]/40",
+    text: "text-[#2d4a35]",
+    iconBg: "ring-[#9cc9a9]/50",
+    iconStroke: "#2d4a35",
+  },
+  MEDIUM: {
+    bg: "bg-[#f4ecc9]/70",
+    ring: "ring-[#d9c97a]/40",
+    text: "text-[#6b5a20]",
+    iconBg: "ring-[#d9c97a]/50",
+    iconStroke: "#6b5a20",
+  },
+  LOW: {
+    bg: "bg-[#fde4d4]/70",
+    ring: "ring-[#fab89a]/40",
+    text: "text-[#8b4a2f]",
+    iconBg: "ring-[#fab89a]/50",
+    iconStroke: "#8b4a2f",
+  },
+};
+
 // ── answer parsing ────────────────────────────────────────────────────────
 // Generator emits [^N] markers (see pipeline/nodes/generate.ts).
 


### PR DESCRIPTION
## Summary

- Adds a `CONFIDENCE_COLORS` token map in `shared.ts`, keyed by `ConfidenceTier`, carrying `{ bg, ring, text, iconBg, iconStroke }` so the badge's palette lives next to the tier logic.
- Extracts `ConfidenceBadge` into its own file (`app/_components/confidence-badge.tsx`) and drives its render off the tokens — single JSX tree, no peach/sage if/else.
- HIGH reuses the existing sage (green), LOW reuses the existing peach (orange), MEDIUM introduces a muted ochre-yellow consistent with the aesthetic.
- Icon glyphs: check (HIGH), info-dot (MEDIUM), alert (LOW).
- Hex literals used elsewhere (citation chips, trace section, sidebar, authority styles) are untouched.

Closes #64

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Manual check on `/` with HIGH / MEDIUM / LOW retrievals

[REVIEWER AGENT] APPROVED

https://claude.ai/code/session_01G5sLhGrMqAm2kW8PQiMp7x