### PR TITLE
Loosen confidence thresholds to 0.65 / 0.45

### DIFF
--- a/app/_components/confidence-badge.tsx
+++ b/app/_components/confidence-badge.tsx
@@ -1,7 +1,7 @@
 import { SERIF, CONFIDENCE_COLORS, type ConfidenceTier } from "./shared";
 
 const CONFIDENCE_TOOLTIP =
-  "Based on the semantic similarity score of the best-matching source retrieved for your question. High = score ≥ 0.8, Medium = score ≥ 0.55, Low = score < 0.55.";
+  "Based on the semantic similarity score of the best-matching source retrieved for your question. High = score ≥ 0.65, Medium = score ≥ 0.45, Low = score < 0.45.";
 
 const TIER_LABEL: Record<ConfidenceTier, string> = {
   HIGH: "High",

--- a/app/_components/shared.ts
+++ b/app/_components/shared.ts
@@ -71,8 +71,8 @@ export function confidenceTier(
 ): ConfidenceTier {
   if (retrievals.length === 0) return "LOW";
   const top = Math.max(...retrievals.map((r) => r.score));
-  if (top >= 0.8) return "HIGH";
-  if (top >= 0.55) return "MEDIUM";
+  if (top >= 0.65) return "HIGH";
+  if (top >= 0.45) return "MEDIUM";
   return "LOW";
 }
 

--- a/tests/unit/confidence-tier.test.ts
+++ b/tests/unit/confidence-tier.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Unit test for app/_components/shared.ts `confidenceTier` — verifies the
+ * relaxed thresholds appropriate for text-embedding-3-small cosine scores:
+ *   HIGH   when top score >= 0.65
+ *   MEDIUM when top score >= 0.45
+ *   LOW    otherwise (and for an empty retrievals array)
+ */
+
+import { describe, it, expect } from "vitest";
+import { confidenceTier } from "../../app/_components/shared";
+import type { Retrieval } from "../../shared/types";
+
+function r(score: number): Retrieval {
+  return {
+    chunkId: `chunk-${score}`,
+    text: "sample",
+    score,
+  };
+}
+
+describe("confidenceTier", () => {
+  it("returns LOW for an empty retrievals array", () => {
+    expect(confidenceTier([])).toBe("LOW");
+  });
+
+  it("returns HIGH when the top score is exactly 0.65 (inclusive boundary)", () => {
+    expect(confidenceTier([r(0.65)])).toBe("HIGH");
+  });
+
+  it("returns MEDIUM when the top score is exactly 0.45 (inclusive boundary)", () => {
+    expect(confidenceTier([r(0.45)])).toBe("MEDIUM");
+  });
+
+  it("returns MEDIUM when the top score is 0.55", () => {
+    expect(confidenceTier([r(0.55)])).toBe("MEDIUM");
+  });
+
+  it("returns LOW when the top score is 0.30", () => {
+    expect(confidenceTier([r(0.3)])).toBe("LOW");
+  });
+});


### PR DESCRIPTION
## Summary

- Relaxes `confidenceTier` in `app/_components/shared.ts`: HIGH ≥ 0.65 (was 0.8), MEDIUM ≥ 0.45 (was 0.55). Empty array still returns LOW.
- Updates `CONFIDENCE_TOOLTIP` copy in `answer-card.tsx` to match the new numbers.
- Adds `tests/unit/confidence-tier.test.ts` covering the boundaries (empty → LOW, 0.65 → HIGH, 0.45 → MEDIUM, 0.55 → MEDIUM, 0.30 → LOW).
- `RETRIEVE_THRESHOLD`, `tierForRatio`, and `tierForJudge` are untouched — those serve different purposes (retrieval filter, eval dashboard).

Closes #65

## Test plan

- [x] `pnpm vitest run tests/unit/confidence-tier.test.ts` (5/5 passing)
- [x] `pnpm typecheck`
- [x] `pnpm lint`

[REVIEWER AGENT] APPROVED

https://claude.ai/code/session_01G5sLhGrMqAm2kW8PQiMp7x