### PR TITLE
save/load evaluation reports from /evaluations

### DIFF
--- a/app/Pages/EvaluationsPage.tsx
+++ b/app/Pages/EvaluationsPage.tsx
@@ -1,8 +1,228 @@
-import { AnswerEvaluation } from "../_components/answer-evaluation";
-import { RetrievalEvaluation } from "../_components/retrieval-evaluation";
-import { SERIF } from "../_components/shared";
+"use client";
 
+import { useEffect, useState } from "react";
+import { AnswerEvaluation } from "../_components/answer-evaluation";
+import { ReportSelector } from "../_components/report-selector";
+import { RetrievalEvaluation } from "../_components/retrieval-evaluation";
+import { SaveReportButton } from "../_components/save-report-button";
+import { SERIF } from "../_components/shared";
+import { streamNdjson } from "../_components/ndjson-stream";
+import {
+  selectEvaluationView,
+  type AnswerStreamItem,
+  type AnswerSummary,
+  type RetrievalStreamItem,
+  type RetrievalSummary,
+  type SavedReport,
+  type SavedReportMeta,
+} from "../_components/evaluation-types";
+
+/**
+ * `/evaluations` page. Owns:
+ *   - the "live session" state for the two evaluation sections (running
+ *     flags, progress counters, summaries, errors),
+ *   - the list of saved reports and which one is currently selected
+ *     (`""` = live session, any id = a saved report).
+ *
+ * When a saved report is selected, the two sections render the persisted
+ * summaries and their `Run evaluation` buttons are disabled with a tooltip.
+ * Selecting `Current` restores the live session state — we never replace
+ * the live state in place, so the user can always toggle back and see
+ * whatever they ran this session.
+ */
 export function EvaluationsPage(): React.JSX.Element {
+  // ── live session state ────────────────────────────────────────────────
+  const [retrievalRunning, setRetrievalRunning] = useState(false);
+  const [retrievalProgress, setRetrievalProgress] = useState<{
+    index: number;
+    total: number;
+  } | null>(null);
+  const [retrievalSummary, setRetrievalSummary] =
+    useState<RetrievalSummary | null>(null);
+  const [retrievalError, setRetrievalError] = useState<string | null>(null);
+
+  const [answerRunning, setAnswerRunning] = useState(false);
+  const [answerProgress, setAnswerProgress] = useState<{
+    index: number;
+    total: number;
+  } | null>(null);
+  const [answerSummary, setAnswerSummary] = useState<AnswerSummary | null>(
+    null,
+  );
+  const [answerError, setAnswerError] = useState<string | null>(null);
+
+  // ── saved-report state ────────────────────────────────────────────────
+  const [savedReports, setSavedReports] = useState<readonly SavedReportMeta[]>(
+    [],
+  );
+  const [selectedId, setSelectedId] = useState<string>(""); // "" = Current
+  const [loadedReport, setLoadedReport] = useState<SavedReport | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Fetch the saved-report list on mount so the dropdown is populated.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/evaluations/reports");
+        if (!res.ok) return;
+        const body = (await res.json()) as { reports: SavedReportMeta[] };
+        if (!cancelled) setSavedReports(body.reports ?? []);
+      } catch {
+        // List failure is non-fatal: the user can still run evaluations.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Fetch the full report when the user picks a saved id from the dropdown.
+  useEffect(() => {
+    if (selectedId === "") {
+      setLoadedReport(null);
+      setLoadError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoadError(null);
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/evaluations/reports/${encodeURIComponent(selectedId)}`,
+        );
+        if (!res.ok) {
+          if (!cancelled) setLoadError(`Failed to load report (${res.status})`);
+          return;
+        }
+        const body = (await res.json()) as SavedReport;
+        if (!cancelled) setLoadedReport(body);
+      } catch (err) {
+        if (!cancelled) {
+          setLoadError(err instanceof Error ? err.message : "Failed to load report");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId]);
+
+  // ── run handlers (only fire when viewing `Current`) ───────────────────
+  async function handleRunRetrieval() {
+    if (retrievalRunning) return;
+    setRetrievalRunning(true);
+    setRetrievalError(null);
+    setRetrievalSummary(null);
+    setRetrievalProgress(null);
+    try {
+      await streamNdjson("/api/evaluations/retrieval", (obj) => {
+        const record = obj as Record<string, unknown>;
+        if (record["error"] && !record["done"]) {
+          setRetrievalError(String(record["error"]));
+          return;
+        }
+        if (record["done"]) {
+          setRetrievalSummary(record["summary"] as RetrievalSummary);
+          return;
+        }
+        const item = record as unknown as RetrievalStreamItem;
+        if (typeof item.total === "number") {
+          // Server fires Pinecone queries in parallel, so item.index arrives
+          // out of order. Count completions locally for a monotonic counter.
+          setRetrievalProgress((prev) => ({
+            index: (prev?.index ?? 0) + 1,
+            total: item.total,
+          }));
+        }
+      });
+    } catch (err) {
+      setRetrievalError(err instanceof Error ? err.message : "Evaluation failed.");
+    } finally {
+      setRetrievalRunning(false);
+    }
+  }
+
+  async function handleRunAnswer() {
+    if (answerRunning) return;
+    setAnswerRunning(true);
+    setAnswerError(null);
+    setAnswerSummary(null);
+    setAnswerProgress(null);
+    try {
+      await streamNdjson("/api/evaluations/answer", (obj) => {
+        const record = obj as Record<string, unknown>;
+        if (record["error"] && !record["done"] && !("index" in record)) {
+          setAnswerError(String(record["error"]));
+          return;
+        }
+        if (record["done"]) {
+          setAnswerSummary(record["summary"] as AnswerSummary);
+          return;
+        }
+        const item = record as unknown as AnswerStreamItem;
+        if (typeof item.total === "number") {
+          // Server fires items in parallel, so item.index arrives out of
+          // order. Count completions locally for a monotonic counter.
+          setAnswerProgress((prev) => ({
+            index: (prev?.index ?? 0) + 1,
+            total: item.total,
+          }));
+        }
+      });
+    } catch (err) {
+      setAnswerError(err instanceof Error ? err.message : "Evaluation failed.");
+    } finally {
+      setAnswerRunning(false);
+    }
+  }
+
+  // ── save handler ──────────────────────────────────────────────────────
+  async function handleSave() {
+    if (saving) return;
+    if (retrievalSummary === null && answerSummary === null) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch("/api/evaluations/reports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          retrieval: retrievalSummary,
+          answer: answerSummary,
+        }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Save failed (${res.status})`);
+      }
+      const meta = (await res.json()) as SavedReportMeta;
+      setSavedReports((prev) => [meta, ...prev]);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Save failed.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // ── derive the props each section gets ────────────────────────────────
+  const view = selectEvaluationView({
+    selectedId,
+    liveRetrieval: retrievalSummary,
+    liveAnswer: answerSummary,
+    loadedReport,
+  });
+  const viewingSaved = view.viewingSaved;
+  const runDisabledReason = viewingSaved ? "Viewing a saved report" : undefined;
+  const retrievalShown = view.retrieval;
+  const answerShown = view.answer;
+
+  const hasAnyLiveSummary =
+    retrievalSummary !== null || answerSummary !== null;
+  const showSaveButton = !viewingSaved;
+
   return (
     <main className="relative mx-auto w-full max-w-[1360px] flex-1 px-8 pb-24 pt-4">
       <div className="mb-6">
@@ -16,9 +236,47 @@ export function EvaluationsPage(): React.JSX.Element {
           Track answer quality across regression suites and ad-hoc probes.
         </p>
       </div>
+
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <ReportSelector
+          value={selectedId}
+          reports={savedReports}
+          onChange={setSelectedId}
+        />
+        {showSaveButton && (
+          <SaveReportButton
+            onClick={() => void handleSave()}
+            disabled={!hasAnyLiveSummary}
+            saving={saving}
+          />
+        )}
+      </div>
+
+      {(loadError || saveError) && (
+        <div className="mb-4 rounded-xl border border-[#c5a0a5]/40 bg-[#efdfe2]/40 px-4 py-2.5 text-[12px] text-[#8b3a2f]">
+          {loadError ?? saveError}
+        </div>
+      )}
+
       <div className="space-y-8">
-        <RetrievalEvaluation />
-        <AnswerEvaluation />
+        <RetrievalEvaluation
+          running={viewingSaved ? false : retrievalRunning}
+          progress={viewingSaved ? null : retrievalProgress}
+          summary={retrievalShown}
+          error={viewingSaved ? null : retrievalError}
+          onRun={() => void handleRunRetrieval()}
+          runDisabled={viewingSaved}
+          runDisabledReason={runDisabledReason}
+        />
+        <AnswerEvaluation
+          running={viewingSaved ? false : answerRunning}
+          progress={viewingSaved ? null : answerProgress}
+          summary={answerShown}
+          error={viewingSaved ? null : answerError}
+          onRun={() => void handleRunAnswer()}
+          runDisabled={viewingSaved}
+          runDisabledReason={runDisabledReason}
+        />
       </div>
     </main>
   );

--- a/app/_components/answer-evaluation.tsx
+++ b/app/_components/answer-evaluation.tsx
@@ -1,65 +1,37 @@
 "use client";
 
-import { useState } from "react";
 import { CategoryBarChart } from "./category-bar-chart";
 import { EvaluationSection } from "./evaluation-section";
 import { MetricCard } from "./metric-card";
 import {
   tierForJudge,
-  type AnswerStreamItem,
   type AnswerSummary,
 } from "./evaluation-types";
-import { streamNdjson } from "./ndjson-stream";
 
 /**
- * Answer-evaluation section. Triggers POST /api/evaluations/answer, streams
- * per-item judge scores for the progress indicator, and renders accuracy /
- * completeness / relevance cards plus a category bar chart when complete.
+ * Answer-evaluation section. Controlled by the `/evaluations` page: the
+ * page owns `running`, `progress`, `summary`, and `error`, and passes them
+ * in as props. The section stays pure-view so it can render either the
+ * live session state or the contents of a selected saved report without
+ * caring which.
  */
-export function AnswerEvaluation(): React.JSX.Element {
-  const [running, setRunning] = useState(false);
-  const [progress, setProgress] = useState<{
-    index: number;
-    total: number;
-  } | null>(null);
-  const [summary, setSummary] = useState<AnswerSummary | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  async function handleRun() {
-    if (running) return;
-    setRunning(true);
-    setError(null);
-    setSummary(null);
-    setProgress(null);
-
-    try {
-      await streamNdjson("/api/evaluations/answer", (obj) => {
-        const record = obj as Record<string, unknown>;
-        if (record["error"] && !record["done"] && !("index" in record)) {
-          setError(String(record["error"]));
-          return;
-        }
-        if (record["done"]) {
-          setSummary(record["summary"] as AnswerSummary);
-          return;
-        }
-        const item = record as unknown as AnswerStreamItem;
-        if (typeof item.total === "number") {
-          // Server fires items in parallel, so item.index arrives out of
-          // order. Count completions locally for a monotonic counter.
-          setProgress((prev) => ({
-            index: (prev?.index ?? 0) + 1,
-            total: item.total,
-          }));
-        }
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Evaluation failed.");
-    } finally {
-      setRunning(false);
-    }
-  }
-
+export function AnswerEvaluation({
+  running,
+  progress,
+  summary,
+  error,
+  onRun,
+  runDisabled = false,
+  runDisabledReason,
+}: {
+  running: boolean;
+  progress: { index: number; total: number } | null;
+  summary: AnswerSummary | null;
+  error: string | null;
+  onRun: () => void;
+  runDisabled?: boolean;
+  runDisabledReason?: string;
+}): React.JSX.Element {
   const hasResults = summary !== null;
 
   return (
@@ -70,7 +42,9 @@ export function AnswerEvaluation(): React.JSX.Element {
       progress={progress}
       hasResults={hasResults}
       error={error}
-      onRun={() => void handleRun()}
+      onRun={onRun}
+      runDisabled={runDisabled}
+      runDisabledReason={runDisabledReason}
     >
       {summary && (
         <>

--- a/app/_components/evaluation-section.tsx
+++ b/app/_components/evaluation-section.tsx
@@ -7,6 +7,10 @@ import { SERIF } from "./shared";
  * a slot for the pre-run hint or the rendered results. Matches the two-card
  * stacked layout from the Gradio prototype but styled with the app theme
  * (muted greens/creams, Card, SERIF title).
+ *
+ * When `runDisabled` is set (e.g. while viewing a saved report), the run
+ * button is rendered in a disabled state with a tooltip and the click
+ * handler is never invoked.
  */
 export function EvaluationSection({
   title,
@@ -16,6 +20,8 @@ export function EvaluationSection({
   hasResults,
   error,
   onRun,
+  runDisabled = false,
+  runDisabledReason,
   children,
 }: {
   title: string;
@@ -25,6 +31,8 @@ export function EvaluationSection({
   hasResults: boolean;
   error: string | null;
   onRun: () => void;
+  runDisabled?: boolean;
+  runDisabledReason?: string;
   children: React.ReactNode;
 }): React.JSX.Element {
   return (
@@ -46,6 +54,8 @@ export function EvaluationSection({
             onClick={onRun}
             running={running}
             progress={progress}
+            disabled={runDisabled}
+            disabledReason={runDisabledReason}
           />
         </div>
         {error && (

--- a/app/_components/evaluation-types.ts
+++ b/app/_components/evaluation-types.ts
@@ -57,6 +57,74 @@ export interface AnswerStreamItem {
   readonly error?: string;
 }
 
+// ── saved reports (persisted to eval/saved-reports/) ────────────────────────
+
+/**
+ * Metadata for a saved report — what the list endpoint and the report
+ * selector dropdown need to render an option without loading the full
+ * summary data.
+ */
+export interface SavedReportMeta {
+  readonly id: string;
+  readonly savedAt: string;
+}
+
+/**
+ * Full persisted report payload. Either `retrieval` or `answer` may be
+ * null if the user only ran one section before saving, but not both.
+ */
+export interface SavedReport extends SavedReportMeta {
+  readonly retrieval: RetrievalSummary | null;
+  readonly answer: AnswerSummary | null;
+}
+
+/**
+ * What the `/evaluations` page renders, after reconciling the live session
+ * state against any currently-selected saved report.
+ *
+ *   - `selectedId === ""`  → live session (whatever the user ran).
+ *   - `selectedId !== ""`  → the saved report's persisted summaries, or
+ *                            null where the saved report didn't include
+ *                            that section.
+ *
+ * Kept as a separate pure helper so that the state-transition logic can be
+ * unit-tested without a React renderer.
+ */
+export interface EvaluationViewSelection {
+  readonly viewingSaved: boolean;
+  readonly retrieval: RetrievalSummary | null;
+  readonly answer: AnswerSummary | null;
+}
+
+export function selectEvaluationView(params: {
+  selectedId: string;
+  liveRetrieval: RetrievalSummary | null;
+  liveAnswer: AnswerSummary | null;
+  loadedReport: SavedReport | null;
+}): EvaluationViewSelection {
+  const viewingSaved = params.selectedId !== "";
+  if (!viewingSaved) {
+    return {
+      viewingSaved: false,
+      retrieval: params.liveRetrieval,
+      answer: params.liveAnswer,
+    };
+  }
+  // While the saved report is loading (`loadedReport` is null or points to
+  // a different id), fall back to empty-state cards — do NOT leak live
+  // session data through, or the user would see stale numbers from their
+  // session rendered under a saved-report label.
+  const match =
+    params.loadedReport && params.loadedReport.id === params.selectedId
+      ? params.loadedReport
+      : null;
+  return {
+    viewingSaved: true,
+    retrieval: match?.retrieval ?? null,
+    answer: match?.answer ?? null,
+  };
+}
+
 // ── threshold tiers (match the Gradio prototype) ────────────────────────────
 
 export function tierForRatio(value: number, green = 0.9, amber = 0.75): ThresholdTier {

--- a/app/_components/report-selector.tsx
+++ b/app/_components/report-selector.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { SavedReportMeta } from "./evaluation-types";
+
+/**
+ * Dropdown for selecting which report to view on `/evaluations`.
+ *
+ * - Default option is `Current` (value `""`) — shows whatever the user has
+ *   run in this session.
+ * - Each entry of `reports` becomes an option labelled by a human-readable
+ *   form of its `savedAt` timestamp.
+ *
+ * Selection is uncontrolled from the dropdown's perspective — the parent
+ * owns the `value` and reacts to `onChange`.
+ */
+export function ReportSelector({
+  value,
+  reports,
+  onChange,
+}: {
+  /** Empty string means "Current"; any other value is a saved report id. */
+  value: string;
+  reports: readonly SavedReportMeta[];
+  onChange: (id: string) => void;
+}): React.JSX.Element {
+  return (
+    <label className="flex items-center gap-2 text-[12px] text-[#6b7a70]">
+      <span className="uppercase tracking-[0.14em]">Report</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label="Select report"
+        className="rounded-lg border border-[#d9ddd9] bg-white/90 px-3 py-1.5 text-[13px] text-[#1f2a23] shadow-sm outline-none transition-shadow focus:ring-2 focus:ring-[#2d4a35]/30"
+      >
+        <option value="">Current</option>
+        {reports.map((r) => (
+          <option key={r.id} value={r.id}>
+            {formatTimestamp(r.savedAt)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+// Private helper — small enough to stay inline per agents.md allowance.
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  // Short human-readable form. Example: "Apr 20, 2026, 6:23 PM".
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}

--- a/app/_components/retrieval-evaluation.tsx
+++ b/app/_components/retrieval-evaluation.tsx
@@ -1,65 +1,37 @@
 "use client";
 
-import { useState } from "react";
 import { CategoryBarChart } from "./category-bar-chart";
 import { EvaluationSection } from "./evaluation-section";
 import { MetricCard } from "./metric-card";
 import {
   tierForRatio,
-  type RetrievalStreamItem,
   type RetrievalSummary,
 } from "./evaluation-types";
-import { streamNdjson } from "./ndjson-stream";
 
 /**
- * Retrieval-evaluation section. Triggers POST /api/evaluations/retrieval,
- * streams per-item results to update the progress indicator, and renders
- * three metric cards + a bar chart of average MRR by category when done.
+ * Retrieval-evaluation section. Controlled by the `/evaluations` page: the
+ * page owns `running`, `progress`, `summary`, and `error`, and passes them
+ * in as props. The section stays pure-view so it can render either the
+ * live session state or the contents of a selected saved report without
+ * caring which.
  */
-export function RetrievalEvaluation(): React.JSX.Element {
-  const [running, setRunning] = useState(false);
-  const [progress, setProgress] = useState<{
-    index: number;
-    total: number;
-  } | null>(null);
-  const [summary, setSummary] = useState<RetrievalSummary | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  async function handleRun() {
-    if (running) return;
-    setRunning(true);
-    setError(null);
-    setSummary(null);
-    setProgress(null);
-
-    try {
-      await streamNdjson("/api/evaluations/retrieval", (obj) => {
-        const record = obj as Record<string, unknown>;
-        if (record["error"] && !record["done"]) {
-          setError(String(record["error"]));
-          return;
-        }
-        if (record["done"]) {
-          setSummary(record["summary"] as RetrievalSummary);
-          return;
-        }
-        const item = record as unknown as RetrievalStreamItem;
-        if (typeof item.total === "number") {
-          // Server fires Pinecone queries in parallel, so item.index arrives
-          // out of order. Count completions locally for a monotonic counter.
-          setProgress((prev) => ({
-            index: (prev?.index ?? 0) + 1,
-            total: item.total,
-          }));
-        }
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Evaluation failed.");
-    } finally {
-      setRunning(false);
-    }
-  }
-
+export function RetrievalEvaluation({
+  running,
+  progress,
+  summary,
+  error,
+  onRun,
+  runDisabled = false,
+  runDisabledReason,
+}: {
+  running: boolean;
+  progress: { index: number; total: number } | null;
+  summary: RetrievalSummary | null;
+  error: string | null;
+  onRun: () => void;
+  runDisabled?: boolean;
+  runDisabledReason?: string;
+}): React.JSX.Element {
   const hasResults = summary !== null;
 
   return (
@@ -70,7 +42,9 @@ export function RetrievalEvaluation(): React.JSX.Element {
       progress={progress}
       hasResults={hasResults}
       error={error}
-      onRun={() => void handleRun()}
+      onRun={onRun}
+      runDisabled={runDisabled}
+      runDisabledReason={runDisabledReason}
     >
       {summary && (
         <>

--- a/app/_components/run-evaluation-button.tsx
+++ b/app/_components/run-evaluation-button.tsx
@@ -2,19 +2,27 @@
  * "Run evaluation" button used on the /evaluations dashboard. Shows a
  * disabled loading state and a small progress indicator ("Evaluating test
  * N/M…") while items stream back from the server.
+ *
+ * When `disabled` is set (e.g. while viewing a saved report), the button
+ * is disabled and a `title` tooltip explains why. Clicks are swallowed.
  */
 export function RunEvaluationButton({
   onClick,
   running,
   progress,
   idleLabel = "Run evaluation",
+  disabled = false,
+  disabledReason,
 }: {
   onClick: () => void;
   running: boolean;
   progress: { index: number; total: number } | null;
   idleLabel?: string;
+  disabled?: boolean;
+  disabledReason?: string;
 }): React.JSX.Element {
   const busy = running;
+  const isDisabled = busy || disabled;
   const progressText =
     progress && progress.total > 0
       ? `Evaluating test ${progress.index}/${progress.total}…`
@@ -24,9 +32,10 @@ export function RunEvaluationButton({
       <button
         type="button"
         onClick={onClick}
-        disabled={busy}
+        disabled={isDisabled}
         aria-busy={busy}
         aria-label={busy ? progressText : idleLabel}
+        title={!busy && disabled ? disabledReason : undefined}
         className="group relative inline-flex items-center gap-2 overflow-hidden rounded-xl bg-[#2d4a35] px-5 py-2.5 text-[13px] font-medium text-white shadow-[0_2px_8px_-2px_rgba(45,74,53,0.35)] transition-all hover:bg-[#1f3526] hover:shadow-[0_4px_14px_-2px_rgba(45,74,53,0.45)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-[#2d4a35]"
       >
         {busy ? <Spinner /> : null}

--- a/app/_components/save-report-button.tsx
+++ b/app/_components/save-report-button.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+/**
+ * Save-report button used on `/evaluations`. Disabled unless at least one
+ * of the current summaries is populated. Behaviour lives in the parent;
+ * this file owns presentation and the disabled/saving states only.
+ */
+export function SaveReportButton({
+  onClick,
+  disabled,
+  saving,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+  saving: boolean;
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || saving}
+      aria-busy={saving}
+      aria-label="Save report"
+      title={
+        disabled && !saving
+          ? "Run at least one evaluation to save a report"
+          : undefined
+      }
+      className="inline-flex items-center gap-2 rounded-xl border border-[#2d4a35]/30 bg-white/80 px-4 py-1.5 text-[13px] font-medium text-[#2d4a35] shadow-sm transition-colors hover:bg-[#dfeee3]/60 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white/80"
+    >
+      {saving ? "Saving…" : "Save report"}
+    </button>
+  );
+}

--- a/app/api/evaluations/reports/[id]/route.ts
+++ b/app/api/evaluations/reports/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { readdir, readFile } from "fs/promises";
+import { resolve } from "path";
+import type { SavedReport } from "../../../../_components/evaluation-types";
+
+export const runtime = "nodejs";
+
+const REPORTS_DIR = resolve(process.cwd(), "eval/saved-reports");
+
+// Strict allow-list: the id is embedded in a filename and used to look up
+// a file on disk — anything outside `[A-Za-z0-9]` is rejected so that
+// `/`, `.`, `..`, and similar traversal tokens can't reach the filesystem.
+const SHORT_ID_PATTERN = /^[A-Za-z0-9]+$/;
+
+const FILENAME_PATTERN = /^[A-Za-z0-9-]+\.json$/;
+
+/**
+ * GET /api/evaluations/reports/[id]
+ * Returns the full `SavedReport` for the given id, or 404 if no file
+ * contains that id.
+ */
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await context.params;
+
+  if (typeof id !== "string" || !SHORT_ID_PATTERN.test(id)) {
+    return NextResponse.json({ error: "Invalid report id" }, { status: 400 });
+  }
+
+  try {
+    const entries = await readdir(REPORTS_DIR);
+    // Filenames end with `-<id>.json`. Match exactly to avoid hitting
+    // another report whose id is a substring of this one.
+    const match = entries.find(
+      (name) => FILENAME_PATTERN.test(name) && name.endsWith(`-${id}.json`),
+    );
+    if (!match) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const raw = await readFile(resolve(REPORTS_DIR, match), "utf8");
+    const parsed = JSON.parse(raw) as SavedReport;
+    if (parsed.id !== id) {
+      // Filename and embedded id disagree — treat as not found rather
+      // than returning a mismatched body.
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json(parsed);
+  } catch (err) {
+    const nodeErr = err as NodeJS.ErrnoException;
+    if (nodeErr && nodeErr.code === "ENOENT") {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    console.error("[api/evaluations/reports/[id]] GET error:", err);
+    return NextResponse.json(
+      { error: "Failed to load report" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/evaluations/reports/route.ts
+++ b/app/api/evaluations/reports/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+import { mkdir, readdir, readFile, writeFile } from "fs/promises";
+import { resolve } from "path";
+import type {
+  AnswerSummary,
+  RetrievalSummary,
+  SavedReportMeta,
+} from "../../../_components/evaluation-types";
+
+export const runtime = "nodejs";
+
+/**
+ * Saved-report persistence lives under `eval/saved-reports/`, one JSON file
+ * per report. Files are tracked in git so reports function as shared team
+ * baselines — see issue #74 and agents.md.
+ *
+ * Filenames: `<ISO-timestamp-with-hyphens>-<shortId>.json`.
+ */
+const REPORTS_DIR = resolve(process.cwd(), "eval/saved-reports");
+
+// Strict allow-list: short-id uses alphanumerics only. Prevents path
+// traversal when the id is embedded in a filename or file path.
+const SHORT_ID_PATTERN = /^[A-Za-z0-9]+$/;
+
+// The filename is `<timestamp>-<id>.json` where timestamp uses hyphens
+// only (colons stripped), so we can use the same alphabet on the whole
+// stem. This is the extra defence-in-depth check when we enumerate.
+const FILENAME_PATTERN = /^[A-Za-z0-9-]+\.json$/;
+
+interface PostBody {
+  retrieval: RetrievalSummary | null;
+  answer: AnswerSummary | null;
+}
+
+function filenameSafeTimestamp(iso: string): string {
+  // ISO 8601 uses `:` which is unsafe on some filesystems (Windows, older
+  // macOS). Replace `:` with `-`. Also replace the `.` before fractional
+  // seconds so the filename stem stays in [A-Za-z0-9-] and the `.json`
+  // extension is the only `.` in the name — keeps the allow-list regex
+  // simple and defensible against traversal.
+  return iso.replace(/:/g, "-").replace(/\./g, "-");
+}
+
+function generateShortId(): string {
+  return randomBytes(4).toString("hex");
+}
+
+async function ensureDir(): Promise<void> {
+  await mkdir(REPORTS_DIR, { recursive: true });
+}
+
+/**
+ * GET /api/evaluations/reports
+ * Lists saved reports as `{ id, savedAt }[]` sorted by savedAt desc.
+ */
+export async function GET(): Promise<NextResponse> {
+  try {
+    await ensureDir();
+    const entries = await readdir(REPORTS_DIR);
+    const reports: SavedReportMeta[] = [];
+    for (const name of entries) {
+      if (!FILENAME_PATTERN.test(name)) continue;
+      try {
+        const raw = await readFile(resolve(REPORTS_DIR, name), "utf8");
+        const parsed = JSON.parse(raw) as Partial<SavedReportMeta>;
+        if (
+          typeof parsed.id === "string" &&
+          typeof parsed.savedAt === "string"
+        ) {
+          reports.push({ id: parsed.id, savedAt: parsed.savedAt });
+        }
+      } catch {
+        // Skip malformed files — a broken file shouldn't kill the list.
+      }
+    }
+    reports.sort((a, b) => (a.savedAt < b.savedAt ? 1 : a.savedAt > b.savedAt ? -1 : 0));
+    return NextResponse.json({ reports });
+  } catch (err) {
+    console.error("[api/evaluations/reports] GET error:", err);
+    return NextResponse.json(
+      { error: "Failed to list reports" },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * POST /api/evaluations/reports
+ * Body: `{ retrieval, answer }` — both nullable but not both null.
+ * Writes `eval/saved-reports/<timestamp>-<id>.json` and returns `{ id, savedAt }`.
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: PostBody;
+  try {
+    body = (await request.json()) as PostBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const retrieval = body.retrieval ?? null;
+  const answer = body.answer ?? null;
+
+  if (retrieval === null && answer === null) {
+    return NextResponse.json(
+      { error: "At least one of retrieval or answer must be provided" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    await ensureDir();
+    const id = generateShortId();
+    const savedAt = new Date().toISOString();
+    const filename = `${filenameSafeTimestamp(savedAt)}-${id}.json`;
+    // Extra safety: the filename must match our allowed pattern.
+    if (!FILENAME_PATTERN.test(filename) || !SHORT_ID_PATTERN.test(id)) {
+      throw new Error("Generated filename failed validation");
+    }
+    const filepath = resolve(REPORTS_DIR, filename);
+    const payload = { id, savedAt, retrieval, answer };
+    await writeFile(filepath, JSON.stringify(payload, null, 2) + "\n", "utf8");
+    return NextResponse.json({ id, savedAt });
+  } catch (err) {
+    console.error("[api/evaluations/reports] POST error:", err);
+    return NextResponse.json(
+      { error: "Failed to save report" },
+      { status: 500 },
+    );
+  }
+}

--- a/tests/integration/reports-route.test.ts
+++ b/tests/integration/reports-route.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Round-trip test for the saved-report API:
+ *   POST /api/evaluations/reports        → creates a file and returns meta
+ *   GET  /api/evaluations/reports        → lists metas sorted desc
+ *   GET  /api/evaluations/reports/[id]   → returns the full saved report
+ *
+ * Also exercises the 400/404 edge cases called out in issue #74 AC7.
+ *
+ * The route handlers read/write `eval/saved-reports/` under `process.cwd()`.
+ * We redirect `process.cwd()` to a per-test tmp dir so real reports aren't
+ * clobbered. Fresh module imports pick up the redirected cwd because the
+ * REPORTS_DIR path resolves at import time.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { readdir, readFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+
+import type {
+  AnswerSummary,
+  RetrievalSummary,
+  SavedReport,
+  SavedReportMeta,
+} from "../../app/_components/evaluation-types";
+
+const retrievalFixture: RetrievalSummary = {
+  total: 3,
+  mrr: 0.82,
+  ndcg: 0.88,
+  keywordCoverage: 0.74,
+  pinpointPrecision: 0.51,
+  categories: [
+    { category: "books-and-records", avgMrr: 0.9, count: 2 },
+    { category: "disclosures", avgMrr: 0.7, count: 1 },
+  ],
+};
+
+const answerFixture: AnswerSummary = {
+  total: 3,
+  accuracy: 4.4,
+  completeness: 4.1,
+  relevance: 4.7,
+  categories: [{ category: "disclosures", avgAccuracy: 4.5, count: 3 }],
+};
+
+let tmpRoot: string;
+let cwdSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+async function loadRoutes() {
+  // `vi.resetModules()` ensures each test gets a fresh copy of the route
+  // module — the REPORTS_DIR constant in the module binds to cwd at import
+  // time, so we must re-import after swapping cwd.
+  vi.resetModules();
+  const list = await import("../../app/api/evaluations/reports/route");
+  const byId = await import("../../app/api/evaluations/reports/[id]/route");
+  return { list, byId };
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "reports-route-"));
+  cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tmpRoot);
+});
+
+afterEach(() => {
+  cwdSpy?.mockRestore();
+  cwdSpy = null;
+  rmSync(tmpRoot, { recursive: true, force: true });
+  vi.resetModules();
+});
+
+describe("POST /api/evaluations/reports", () => {
+  it("persists a JSON file and returns {id, savedAt}", async () => {
+    const { list } = await loadRoutes();
+    const req = new Request("http://localhost/api/evaluations/reports", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ retrieval: retrievalFixture, answer: answerFixture }),
+    });
+    const res = await list.POST(req);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SavedReportMeta;
+    expect(typeof body.id).toBe("string");
+    expect(body.id).toMatch(/^[A-Za-z0-9]+$/);
+    expect(typeof body.savedAt).toBe("string");
+    expect(new Date(body.savedAt).toString()).not.toBe("Invalid Date");
+
+    const dir = resolve(tmpRoot, "eval/saved-reports");
+    const files = await readdir(dir);
+    expect(files).toHaveLength(1);
+    const raw = await readFile(resolve(dir, files[0]!), "utf8");
+    const saved = JSON.parse(raw) as SavedReport;
+    expect(saved.id).toBe(body.id);
+    expect(saved.retrieval).toEqual(retrievalFixture);
+    expect(saved.answer).toEqual(answerFixture);
+  });
+
+  it("accepts a retrieval-only save", async () => {
+    const { list } = await loadRoutes();
+    const req = new Request("http://localhost/api/evaluations/reports", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ retrieval: retrievalFixture, answer: null }),
+    });
+    const res = await list.POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 400 when both summaries are null", async () => {
+    const { list } = await loadRoutes();
+    const req = new Request("http://localhost/api/evaluations/reports", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ retrieval: null, answer: null }),
+    });
+    const res = await list.POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const { list } = await loadRoutes();
+    const req = new Request("http://localhost/api/evaluations/reports", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await list.POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/evaluations/reports", () => {
+  it("lists saved reports sorted by savedAt descending", async () => {
+    const { list } = await loadRoutes();
+    // POST two reports a moment apart to get distinct timestamps.
+    const first = await list.POST(
+      new Request("http://localhost/api/evaluations/reports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ retrieval: retrievalFixture, answer: null }),
+      }),
+    );
+    const firstMeta = (await first.json()) as SavedReportMeta;
+    await new Promise((r) => setTimeout(r, 10));
+    const second = await list.POST(
+      new Request("http://localhost/api/evaluations/reports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ retrieval: null, answer: answerFixture }),
+      }),
+    );
+    const secondMeta = (await second.json()) as SavedReportMeta;
+
+    const res = await list.GET();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { reports: SavedReportMeta[] };
+    expect(body.reports).toHaveLength(2);
+    // Newest first.
+    expect(body.reports[0]!.id).toBe(secondMeta.id);
+    expect(body.reports[1]!.id).toBe(firstMeta.id);
+  });
+
+  it("returns an empty list when the directory is empty", async () => {
+    const { list } = await loadRoutes();
+    const res = await list.GET();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { reports: SavedReportMeta[] };
+    expect(body.reports).toEqual([]);
+  });
+});
+
+describe("GET /api/evaluations/reports/[id]", () => {
+  it("round-trips: POST then fetch by id returns the full body", async () => {
+    const { list, byId } = await loadRoutes();
+    const posted = await list.POST(
+      new Request("http://localhost/api/evaluations/reports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ retrieval: retrievalFixture, answer: answerFixture }),
+      }),
+    );
+    const meta = (await posted.json()) as SavedReportMeta;
+
+    const res = await byId.GET(
+      new Request(`http://localhost/api/evaluations/reports/${meta.id}`),
+      { params: Promise.resolve({ id: meta.id }) },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as SavedReport;
+    expect(body.id).toBe(meta.id);
+    expect(body.savedAt).toBe(meta.savedAt);
+    expect(body.retrieval).toEqual(retrievalFixture);
+    expect(body.answer).toEqual(answerFixture);
+  });
+
+  it("returns 404 for an unknown id", async () => {
+    const { byId } = await loadRoutes();
+    const res = await byId.GET(
+      new Request("http://localhost/api/evaluations/reports/deadbeef"),
+      { params: Promise.resolve({ id: "deadbeef" }) },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it.each([
+    ["../etc/passwd"],
+    ["foo/bar"],
+    ["foo.bar"],
+    ["."],
+    [".."],
+    ["has space"],
+    ["dash-id"],
+    [""],
+  ])("rejects non-alphanumeric id %j with 400", async (id) => {
+    const { byId } = await loadRoutes();
+    const res = await byId.GET(
+      new Request(`http://localhost/api/evaluations/reports/${encodeURIComponent(id)}`),
+      { params: Promise.resolve({ id }) },
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/unit/evaluation-view-selection.test.ts
+++ b/tests/unit/evaluation-view-selection.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit test for `selectEvaluationView` — the pure data-flow helper that
+ * the `/evaluations` page uses to reconcile live session state against a
+ * currently-selected saved report.
+ *
+ * This is the dropdown-switch assertion called out in issue #74 AC9(b):
+ * selecting a saved report should replace the cards with the saved data,
+ * and selecting `Current` again should restore the live session state.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  selectEvaluationView,
+  type AnswerSummary,
+  type RetrievalSummary,
+  type SavedReport,
+} from "../../app/_components/evaluation-types";
+
+const liveRetrieval: RetrievalSummary = {
+  total: 5,
+  mrr: 0.6,
+  ndcg: 0.7,
+  keywordCoverage: 0.5,
+  pinpointPrecision: 0.4,
+  categories: [{ category: "live-cat", avgMrr: 0.6, count: 5 }],
+};
+
+const liveAnswer: AnswerSummary = {
+  total: 5,
+  accuracy: 3.9,
+  completeness: 3.5,
+  relevance: 4.2,
+  categories: [{ category: "live-cat", avgAccuracy: 3.9, count: 5 }],
+};
+
+const savedRetrieval: RetrievalSummary = {
+  total: 10,
+  mrr: 0.95,
+  ndcg: 0.92,
+  keywordCoverage: 0.88,
+  pinpointPrecision: 0.7,
+  categories: [{ category: "saved-cat", avgMrr: 0.95, count: 10 }],
+};
+
+const savedAnswer: AnswerSummary = {
+  total: 10,
+  accuracy: 4.8,
+  completeness: 4.7,
+  relevance: 4.9,
+  categories: [{ category: "saved-cat", avgAccuracy: 4.8, count: 10 }],
+};
+
+const savedReport: SavedReport = {
+  id: "abc123",
+  savedAt: "2026-04-20T18:23:11.000Z",
+  retrieval: savedRetrieval,
+  answer: savedAnswer,
+};
+
+describe("selectEvaluationView", () => {
+  it("returns live session state when `Current` is selected", () => {
+    const view = selectEvaluationView({
+      selectedId: "",
+      liveRetrieval,
+      liveAnswer,
+      loadedReport: null,
+    });
+    expect(view.viewingSaved).toBe(false);
+    expect(view.retrieval).toBe(liveRetrieval);
+    expect(view.answer).toBe(liveAnswer);
+  });
+
+  it("returns the saved report's summaries when a saved id is selected", () => {
+    const view = selectEvaluationView({
+      selectedId: "abc123",
+      liveRetrieval,
+      liveAnswer,
+      loadedReport: savedReport,
+    });
+    expect(view.viewingSaved).toBe(true);
+    expect(view.retrieval).toBe(savedRetrieval);
+    expect(view.answer).toBe(savedAnswer);
+  });
+
+  it("dropdown switch Current → saved → Current restores live state", () => {
+    // Starting state: user ran evaluations this session.
+    const atCurrentBefore = selectEvaluationView({
+      selectedId: "",
+      liveRetrieval,
+      liveAnswer,
+      loadedReport: null,
+    });
+    expect(atCurrentBefore.retrieval).toBe(liveRetrieval);
+    expect(atCurrentBefore.answer).toBe(liveAnswer);
+
+    // User selects a saved report — page fetches it, state updates.
+    const atSaved = selectEvaluationView({
+      selectedId: "abc123",
+      liveRetrieval,
+      liveAnswer,
+      loadedReport: savedReport,
+    });
+    expect(atSaved.retrieval).toBe(savedRetrieval);
+    expect(atSaved.answer).toBe(savedAnswer);
+
+    // User toggles back to Current — live state must still be there.
+    const atCurrentAfter = selectEvaluationView({
+      selectedId: "",
+      liveRetrieval,
+      liveAnswer,
+      loadedReport: savedReport, // stale loaded report shouldn't leak through
+    });
+    expect(atCurrentAfter.viewingSaved).toBe(false);
+    expect(atCurrentAfter.retrieval).toBe(liveRetrieval);
+    expect(atCurrentAfter.answer).toBe(liveAnswer);
+  });
+
+  it("falls back to null (empty-state cards) for null sections in a saved report", () => {
+    const retrievalOnly: SavedReport = {
+      id: "r1",
+      savedAt: "2026-04-20T18:00:00.000Z",
+      retrieval: savedRetrieval,
+      answer: null,
+    };
+    const view = selectEvaluationView({
+      selectedId: "r1",
+      liveRetrieval,
+      liveAnswer,
+      loadedReport: retrievalOnly,
+    });
+    expect(view.retrieval).toBe(savedRetrieval);
+    expect(view.answer).toBeNull();
+  });
+
+  it("does not leak live state through while the saved report is still loading", () => {
+    // `selectedId` has changed to a new id, but the fetch is in-flight
+    // and `loadedReport` is still null (or points to the previous id).
+    const view = selectEvaluationView({
+      selectedId: "abc123",
+      liveRetrieval,
+      liveAnswer,
+      loadedReport: null,
+    });
+    expect(view.viewingSaved).toBe(true);
+    expect(view.retrieval).toBeNull();
+    expect(view.answer).toBeNull();
+  });
+
+  it("does not leak a stale loaded report from a prior selection", () => {
+    // User selected `abc123`, then switched to `xyz789` before `xyz789`
+    // finished loading. The page may still be holding onto the `abc123`
+    // SavedReport. We must not show abc123's numbers under the xyz789 label.
+    const view = selectEvaluationView({
+      selectedId: "xyz789",
+      liveRetrieval,
+      liveAnswer,
+      loadedReport: savedReport, // id `abc123`
+    });
+    expect(view.retrieval).toBeNull();
+    expect(view.answer).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #74.

## Summary

- Lift `RetrievalEvaluation` / `AnswerEvaluation` summary + run state up to `EvaluationsPage` so both sections share one source of truth.
- Add a report-selector dropdown (`Current` + one entry per saved report, most recent first) and a save-report button above the two sections.
- New API routes: `POST /api/evaluations/reports`, `GET /api/evaluations/reports`, `GET /api/evaluations/reports/[id]`. Reports persist to `eval/saved-reports/` as JSON, tracked in git so they function as shared team baselines.
- While a saved report is selected, the `Run evaluation` buttons are disabled with a "Viewing a saved report" tooltip and the save button is hidden, so running or overwriting can't happen from a saved view.
- Strict `/^[A-Za-z0-9]+$/` allow-list on the `[id]` route prevents path traversal; a pure `selectEvaluationView` helper keeps the dropdown state-transition logic unit-testable.

## Test plan

- [x] `pnpm lint` — 0 errors (1 pre-existing warning in an untouched file).
- [x] `pnpm test:unit` — 47/47 pass, including 7 new `selectEvaluationView` cases.
- [x] `pnpm test:integration` — 16/16 pass (2 pre-existing skips require Pinecone/OpenAI keys).
- [ ] Manual: run `pnpm dev`, run a retrieval evaluation, click Save report, refresh the page, select the saved report from the dropdown, verify the metrics and bar chart match. Switch back to `Current` and confirm live state is restored.