### PR TITLE
Sidebar logo: switch Copilot wordmark to Sumana

### DIFF
--- a/app/_components/shared.ts
+++ b/app/_components/shared.ts
@@ -3,6 +3,7 @@ import type { Citation, ChunkMetadata, Retrieval } from "../../shared/types";
 // ── visual tokens ─────────────────────────────────────────────────────────
 
 export const SERIF = { fontFamily: "var(--font-serif)" };
+export const LOGO_FONT = { fontFamily: "var(--font-logo)" };
 
 // ── authority styles ──────────────────────────────────────────────────────
 

--- a/app/_components/sidebar.tsx
+++ b/app/_components/sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LeafMark } from "./leaf-mark";
-import { SERIF } from "./shared";
+import { LOGO_FONT } from "./shared";
 
 const NAV_ITEMS = [
   { href: "/", label: "Dashboard", icon: DashboardIcon },
@@ -26,7 +26,7 @@ export function Sidebar(): React.JSX.Element {
         </div>
         <span
           className="text-[17px] tracking-tight text-[#1f2a23]"
-          style={SERIF}
+          style={LOGO_FONT}
         >
           Copilot
         </span>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Instrument_Serif } from "next/font/google";
+import { Geist, Instrument_Serif, Sumana } from "next/font/google";
 import "./globals.css";
 import { BackgroundLayers } from "./_components/background-layers";
 import { Sidebar } from "./_components/sidebar";
@@ -17,6 +17,12 @@ const serif = Instrument_Serif({
   style: ["normal", "italic"],
 });
 
+const logo = Sumana({
+  weight: ["400", "700"],
+  subsets: ["latin"],
+  variable: "--font-logo",
+});
+
 export const metadata: Metadata = {
   title: "Compliance Copilot",
   description:
@@ -31,7 +37,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geist.variable} ${serif.variable} min-h-screen text-[#2a2f2c] antialiased`}
+        className={`${geist.variable} ${serif.variable} ${logo.variable} min-h-screen text-[#2a2f2c] antialiased`}
         style={{ fontFamily: "var(--font-sans)" }}
       >
         <div className="relative flex min-h-screen">


### PR DESCRIPTION
Closes #76.

Loads Sumana via `next/font/google` in `app/layout.tsx`, exposes it as `--font-logo`, adds a `LOGO_FONT` constant in `app/_components/shared.ts`, and swaps the `"Copilot"` span in `app/_components/sidebar.tsx` to use it. Change is additive — `SERIF` / Instrument Serif remains unchanged for every other heading.