### PR TITLE
Background: three-layer redesign (gradient + radial + bottom tile)

### DIFF
--- a/app/_components/background-layers.tsx
+++ b/app/_components/background-layers.tsx
@@ -1,37 +1,56 @@
+// Tile asset choice: inline SVG data URI (soft repeating leaf-dot motif).
+// Placeholder only — will be swapped for real artwork in a follow-up ticket.
+
+const TILE_SVG =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
+      <g fill="#2d4a35" fill-opacity="0.6">
+        <circle cx="128" cy="896" r="3" />
+        <circle cx="256" cy="832" r="2" />
+        <circle cx="384" cy="928" r="4" />
+        <circle cx="512" cy="864" r="2" />
+        <circle cx="640" cy="912" r="3" />
+        <circle cx="768" cy="848" r="2" />
+        <circle cx="896" cy="896" r="3" />
+        <path d="M192 960 q16 -32 32 0 q-16 -8 -32 0 z" />
+        <path d="M448 976 q16 -32 32 0 q-16 -8 -32 0 z" />
+        <path d="M704 960 q16 -32 32 0 q-16 -8 -32 0 z" />
+        <path d="M960 976 q16 -32 32 0 q-16 -8 -32 0 z" />
+      </g>
+    </svg>`,
+  );
+
 export function BackgroundLayers(): React.JSX.Element {
   return (
     <>
+      {/* Layer 1: vertical pale-green gradient base */}
       <div
         aria-hidden
         className="pointer-events-none fixed inset-0 -z-20"
         style={{
-          background:
-            "linear-gradient(180deg, #f6faf5 0%, #eef7f0 40%, #e8f3ea 100%)",
+          background: "linear-gradient(180deg, #eaf4ec 0%, #f3f8f2 100%)",
         }}
       />
+      {/* Layer 2: upper-right soft orange → pale-green radial glow */}
       <div
         aria-hidden
         className="pointer-events-none fixed inset-0 -z-10"
         style={{
           background:
-            "radial-gradient(ellipse 900px 520px at 92% -8%, rgba(253,228,212,0.9) 0%, rgba(253,228,212,0) 60%)",
+            "radial-gradient(ellipse 1100px 700px at 95% -5%, rgba(253,228,212,0.55) 0%, rgba(234,244,236,0.0) 55%)",
+          opacity: 0.55,
         }}
       />
+      {/* Layer 3: large 1024 tile pattern, tiled horizontally across the bottom */}
       <div
         aria-hidden
-        className="pointer-events-none fixed inset-0 -z-10"
+        className="pointer-events-none fixed inset-0 -z-10 opacity-[0.08]"
         style={{
-          background:
-            "radial-gradient(ellipse 700px 400px at -5% 110%, rgba(156,201,169,0.4) 0%, rgba(156,201,169,0) 55%)",
-        }}
-      />
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 -z-10 opacity-[0.04]"
-        style={{
-          backgroundImage:
-            "linear-gradient(to right, #2d4a35 1px, transparent 1px), linear-gradient(to bottom, #2d4a35 1px, transparent 1px)",
-          backgroundSize: "56px 56px",
+          backgroundImage: `url("${TILE_SVG}")`,
+          backgroundSize: "1024px 1024px",
+          backgroundPosition: "bottom center",
+          backgroundRepeat: "repeat-x",
         }}
       />
     </>


### PR DESCRIPTION
Closes #79.

Collapses `BackgroundLayers` from four overlapping layers to exactly three: (1) a vertical pale-green gradient base, (2) an upper-right pale-orange→pale-green radial at reduced opacity, and (3) a 1024×1024 tile pattern anchored to `bottom center` with `repeat-x` at ~0.08 opacity. The tile asset is an inline SVG placeholder (documented in a comment at the top of the file); a real asset will swap in via a follow-up ticket.