### PR TITLE
Ask button: recolor to dark turquoise

### DIFF
--- a/app/_components/question-card.tsx
+++ b/app/_components/question-card.tsx
@@ -46,7 +46,7 @@ export function QuestionCard({
           onClick={onSubmit}
           disabled={disabled}
           aria-label={loading ? "Thinking" : "Ask"}
-          className="group relative h-10 shrink-0 overflow-hidden rounded-xl bg-[#2d4a35] px-5 text-[13px] font-medium text-white shadow-[0_2px_8px_-2px_rgba(45,74,53,0.35)] transition-all hover:bg-[#1f3526] hover:shadow-[0_4px_14px_-2px_rgba(45,74,53,0.45)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-[#2d4a35]"
+          className="group relative h-10 shrink-0 overflow-hidden rounded-xl bg-[#0e6d6b] px-5 text-[13px] font-medium text-white shadow-[0_2px_8px_-2px_rgba(14,109,107,0.35)] transition-all hover:bg-[#0a5754] hover:shadow-[0_4px_14px_-2px_rgba(14,109,107,0.45)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-[#0e6d6b]"
         >
           <span className="relative flex items-center gap-2">
             {loading ? (


### PR DESCRIPTION
Closes #80.

Swaps the Ask button's color classes in `app/_components/question-card.tsx` from the dark-green brand palette to a muted dark turquoise: base `#0e6d6b`, hover `#0a5754`, disabled-hover pinned to the base, and drop-shadow tints updated to `rgba(14,109,107,...)` while keeping the existing 0.35 / 0.45 alphas. Single-line change.