### PR TITLE
Dashboard: cap Q/A column at 700px max-width

### DIFF
--- a/app/Pages/DashboardPage.tsx
+++ b/app/Pages/DashboardPage.tsx
@@ -104,7 +104,7 @@ export function DashboardPage(): React.JSX.Element {
     <main className="relative flex min-w-0 flex-1 px-8 pb-24 pt-4">
       <FlockLoader active={loading} />
       <div className="flex min-w-0 flex-1 gap-8">
-        <section className="min-w-0 flex-1 space-y-6">
+        <section className="min-w-0 max-w-[700px] flex-1 space-y-6">
           <QuestionCard
             query={query}
             setQuery={setQuery}


### PR DESCRIPTION
Closes #86.

Adds `max-w-[700px]` to the Q/A column `<section>` in `app/Pages/DashboardPage.tsx` so the question card, sample-questions slider, answer card, and trace section stop growing past a comfortable reading measure on wide displays. `min-w-0` and `flex-1` preserved, so narrow viewports still shrink responsively.