### PR TITLE
Sidebar logo: rename Copilot wordmark to Starling Data

### DIFF
--- a/app/_components/sidebar.tsx
+++ b/app/_components/sidebar.tsx
@@ -28,7 +28,7 @@ export function Sidebar(): React.JSX.Element {
           className="text-[17px] tracking-tight text-[#1f2a23]"
           style={LOGO_FONT}
         >
-          Copilot
+          Starling Data
         </span>
       </Link>
 


### PR DESCRIPTION
Closes #88.

One-line text change inside the sidebar's logo `<span>`. Metadata title, README, tests, and design-preview copy continue to read "Compliance Copilot".