### PR TITLE
Other pages: convert h1 headings to Sumana (LOGO_FONT)

### DIFF
--- a/app/Pages/EvaluationsPage.tsx
+++ b/app/Pages/EvaluationsPage.tsx
@@ -5,7 +5,7 @@ import { AnswerEvaluation } from "../_components/answer-evaluation";
 import { ReportSelector } from "../_components/report-selector";
 import { RetrievalEvaluation } from "../_components/retrieval-evaluation";
 import { SaveReportButton } from "../_components/save-report-button";
-import { SERIF } from "../_components/shared";
+import { LOGO_FONT } from "../_components/shared";
 import { streamNdjson } from "../_components/ndjson-stream";
 import {
   selectEvaluationView,
@@ -228,7 +228,7 @@ export function EvaluationsPage(): React.JSX.Element {
       <div className="mb-6">
         <h1
           className="text-[28px] tracking-tight text-[#1f2a23]"
-          style={SERIF}
+          style={LOGO_FONT}
         >
           Evaluations
         </h1>

--- a/app/Pages/HistoryPage.tsx
+++ b/app/Pages/HistoryPage.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useEffect, useState } from "react";
 import Link from "next/link";
 import { Card } from "../_components/card";
-import { SERIF } from "../_components/shared";
+import { LOGO_FONT } from "../_components/shared";
 import { HistoryChunk } from "../_components/history-chunk";
 import {
   loadHistory,
@@ -31,7 +31,7 @@ export function HistoryPage(): React.JSX.Element {
       <div className="mb-6">
         <h1
           className="text-[28px] tracking-tight text-[#1f2a23]"
-          style={SERIF}
+          style={LOGO_FONT}
         >
           History
         </h1>

--- a/app/Pages/LibraryDetailPage.tsx
+++ b/app/Pages/LibraryDetailPage.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { Card } from "../_components/card";
 import { Markdown } from "../_components/markdown";
-import { SERIF, authorityStyle, type Authority } from "../_components/shared";
+import { LOGO_FONT, authorityStyle, type Authority } from "../_components/shared";
 import type { CorpusDoc } from "../_lib/corpus";
 
 function isExternalUrl(url: string): boolean {
@@ -39,7 +39,7 @@ export function LibraryDetailPage({
       <div className="mb-6">
         <h1
           className="text-[28px] leading-tight tracking-tight text-[#1f2a23]"
-          style={SERIF}
+          style={LOGO_FONT}
         >
           {doc.title}
         </h1>

--- a/app/Pages/LibraryPage.tsx
+++ b/app/Pages/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { SERIF } from "../_components/shared";
+import { LOGO_FONT } from "../_components/shared";
 import { LibraryCard } from "../_components/library-card";
 import { loadCorpusDocs } from "../_lib/corpus";
 
@@ -10,7 +10,7 @@ export function LibraryPage(): React.JSX.Element {
       <div className="mb-6">
         <h1
           className="text-[28px] tracking-tight text-[#1f2a23]"
-          style={SERIF}
+          style={LOGO_FONT}
         >
           Library
         </h1>


### PR DESCRIPTION
Closes #89.

Swaps `style={SERIF}` → `style={LOGO_FONT}` on the page-level `<h1>` in `EvaluationsPage`, `HistoryPage`, `LibraryPage`, and `LibraryDetailPage`, updating each import. No other SERIF usage touched — card titles, markdown headings, confidence-badge score, and design-preview all remain on Instrument Serif.