### PR TITLE
AGENT: convert question input from textarea to single-line input (#97)

### DIFF
--- a/app/Pages/DashboardPage.tsx
+++ b/app/Pages/DashboardPage.tsx
@@ -31,7 +31,7 @@ export function DashboardPage(): React.JSX.Element {
   );
   const [pulseKey, setPulseKey] = useState(0);
 
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const textareaRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     textareaRef.current?.focus();
@@ -75,7 +75,7 @@ export function DashboardPage(): React.JSX.Element {
     }
   }
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       void handleSubmit();

--- a/app/_components/question-card.tsx
+++ b/app/_components/question-card.tsx
@@ -9,9 +9,9 @@ export function QuestionCard({
   query: string;
   setQuery: (v: string) => void;
   onSubmit: () => void;
-  onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   loading: boolean;
-  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  textareaRef: React.RefObject<HTMLInputElement | null>;
 }): React.JSX.Element {
   const disabled = loading || query.trim().length === 0;
   return (
@@ -27,16 +27,16 @@ export function QuestionCard({
       </div>
       <div className="mt-3 flex items-center gap-3">
         <div className="relative flex-1">
-          <textarea
+          <input
             id="question-input"
+            type="text"
             ref={textareaRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={onKeyDown}
             disabled={loading}
-            rows={1}
             placeholder="e.g. What are baseline requirements for cyber incident detection?"
-            className="block h-10 w-full resize-none rounded-xl border border-[#2d4a35]/10 bg-white px-4 py-0 align-middle text-[15px] leading-10 text-[#1f2a23] placeholder-[#a0a9a4] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.8),0_1px_0_0_rgba(45,74,53,0.04)] focus:border-[#6ea580] focus:outline-none focus:ring-2 focus:ring-[#9cc9a9]/40 disabled:cursor-not-allowed disabled:opacity-60"
+            className="block h-10 w-full rounded-xl border border-[#2d4a35]/10 bg-white px-4 py-0 align-middle text-[15px] leading-10 text-[#1f2a23] placeholder-[#a0a9a4] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.8),0_1px_0_0_rgba(45,74,53,0.04)] focus:border-[#6ea580] focus:outline-none focus:ring-2 focus:ring-[#9cc9a9]/40 disabled:cursor-not-allowed disabled:opacity-60"
           />
         </div>
         <button


### PR DESCRIPTION
Closes #97.

## Summary

- Convert the dashboard question `<textarea>` to `<input type="text">` so the element cannot produce a vertical scrollbar.
- Update ref and keydown types from `HTMLTextAreaElement` to `HTMLInputElement` in `question-card.tsx` and `DashboardPage.tsx`.
- Remove now-redundant `rows={1}` / `resize-none`; keep `h-10`, `leading-10`, and all existing styling.

## Test plan

- [x] `pnpm lint` — 0 errors (1 pre-existing unrelated warning).
- [x] Reviewer verified typecheck clean and all acceptance criteria.
- [ ] Manual: run `pnpm dev`, paste a multi-line string into the question input, confirm no vertical scrollbar, Enter submits, sample-question insertion still works.