### PR TITLE
AGENT: show 'Report Saved' and disable button after successful save (#98)

### DIFF
--- a/app/Pages/EvaluationsPage.tsx
+++ b/app/Pages/EvaluationsPage.tsx
@@ -5,6 +5,10 @@ import { AnswerEvaluation } from "../_components/answer-evaluation";
 import { ReportSelector } from "../_components/report-selector";
 import { RetrievalEvaluation } from "../_components/retrieval-evaluation";
 import { SaveReportButton } from "../_components/save-report-button";
+import {
+  justSavedOnRunStart,
+  justSavedOnSaveComplete,
+} from "../_components/save-report-state";
 import { LOGO_FONT } from "../_components/shared";
 import { streamNdjson } from "../_components/ndjson-stream";
 import {
@@ -60,6 +64,12 @@ export function EvaluationsPage(): React.JSX.Element {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  // `justSaved` is the confirmation flag powering the "Report Saved" button
+  // state. It flips true at the end of a successful POST and flips false the
+  // moment the user kicks off a new retrieval or answer run — that way the
+  // confirmation is tied to the exact payload that was saved, and any new
+  // run (which produces a new summary) re-enables the button.
+  const [justSaved, setJustSaved] = useState(false);
 
   // Fetch the saved-report list on mount so the dropdown is populated.
   useEffect(() => {
@@ -117,6 +127,9 @@ export function EvaluationsPage(): React.JSX.Element {
     setRetrievalError(null);
     setRetrievalSummary(null);
     setRetrievalProgress(null);
+    // A new run invalidates the previous save confirmation — the resulting
+    // summary is different from whatever was persisted.
+    setJustSaved(justSavedOnRunStart());
     try {
       await streamNdjson("/api/evaluations/retrieval", (obj) => {
         const record = obj as Record<string, unknown>;
@@ -151,6 +164,9 @@ export function EvaluationsPage(): React.JSX.Element {
     setAnswerError(null);
     setAnswerSummary(null);
     setAnswerProgress(null);
+    // A new run invalidates the previous save confirmation — the resulting
+    // summary is different from whatever was persisted.
+    setJustSaved(justSavedOnRunStart());
     try {
       await streamNdjson("/api/evaluations/answer", (obj) => {
         const record = obj as Record<string, unknown>;
@@ -200,8 +216,12 @@ export function EvaluationsPage(): React.JSX.Element {
       }
       const meta = (await res.json()) as SavedReportMeta;
       setSavedReports((prev) => [meta, ...prev]);
+      // Success path: flip the button into its "Report Saved" confirmation
+      // state. This only runs if the POST returned ok and parsed cleanly.
+      setJustSaved(justSavedOnSaveComplete(true));
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : "Save failed.");
+      setJustSaved(justSavedOnSaveComplete(false));
     } finally {
       setSaving(false);
     }
@@ -248,6 +268,7 @@ export function EvaluationsPage(): React.JSX.Element {
             onClick={() => void handleSave()}
             disabled={!hasAnyLiveSummary}
             saving={saving}
+            saved={justSaved}
           />
         )}
       </div>

--- a/app/_components/save-report-button.tsx
+++ b/app/_components/save-report-button.tsx
@@ -3,32 +3,40 @@
 /**
  * Save-report button used on `/evaluations`. Disabled unless at least one
  * of the current summaries is populated. Behaviour lives in the parent;
- * this file owns presentation and the disabled/saving states only.
+ * this file owns presentation and the disabled/saving/saved states only.
+ *
+ * When `saved` is true the button locks into a "Report Saved" confirmation
+ * state: the label flips and the button is disabled so the user cannot
+ * accidentally re-POST the same payload. The parent resets `saved` back to
+ * false when a new evaluation run starts.
  */
 export function SaveReportButton({
   onClick,
   disabled,
   saving,
+  saved,
 }: {
   onClick: () => void;
   disabled: boolean;
   saving: boolean;
+  saved: boolean;
 }): React.JSX.Element {
+  const label = saved ? "Report Saved" : saving ? "Saving…" : "Save report";
   return (
     <button
       type="button"
       onClick={onClick}
-      disabled={disabled || saving}
+      disabled={disabled || saving || saved}
       aria-busy={saving}
       aria-label="Save report"
       title={
-        disabled && !saving
+        disabled && !saving && !saved
           ? "Run at least one evaluation to save a report"
           : undefined
       }
       className="inline-flex items-center gap-2 rounded-xl border border-[#2d4a35]/30 bg-white/80 px-4 py-1.5 text-[13px] font-medium text-[#2d4a35] shadow-sm transition-colors hover:bg-[#dfeee3]/60 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white/80"
     >
-      {saving ? "Saving…" : "Save report"}
+      {label}
     </button>
   );
 }

--- a/app/_components/save-report-state.ts
+++ b/app/_components/save-report-state.ts
@@ -1,0 +1,28 @@
+/**
+ * Tiny state-machine helpers for the `Save report` → `Report Saved` flow on
+ * `/evaluations`.
+ *
+ * The confirmation flag (`justSaved`) must flip true after a successful POST
+ * to `/api/evaluations/reports` and flip false the moment the user starts
+ * any new evaluation run, so the confirmation is tied to the exact payload
+ * that was persisted. These pure helpers make that transition unit-testable
+ * without spinning up a React renderer.
+ */
+
+/**
+ * Returns the next `justSaved` value when a new retrieval or answer run
+ * begins. Starting a new run invalidates any prior save confirmation, since
+ * the resulting summary will differ from whatever was persisted.
+ */
+export function justSavedOnRunStart(): boolean {
+  return false;
+}
+
+/**
+ * Returns the next `justSaved` value after a save attempt completes.
+ * `ok === true` → POST succeeded, show "Report Saved".
+ * `ok === false` → POST failed, leave the button enabled for a retry.
+ */
+export function justSavedOnSaveComplete(ok: boolean): boolean {
+  return ok;
+}

--- a/tests/unit/save-report-state.test.ts
+++ b/tests/unit/save-report-state.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the `/evaluations` save-button state machine — the pure
+ * helpers that control when the button flips between "Save report" and
+ * "Report Saved" (issue #98).
+ *
+ * The behaviour under test:
+ *   - starting a new retrieval or answer run must reset `justSaved` to
+ *     false so the button returns to "Save report" once a fresh summary
+ *     arrives (AC2),
+ *   - a successful POST to `/api/evaluations/reports` must set `justSaved`
+ *     to true so the button shows "Report Saved" and disables itself (AC1),
+ *   - a failed POST must leave `justSaved` false so the user can retry.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  justSavedOnRunStart,
+  justSavedOnSaveComplete,
+} from "../../app/_components/save-report-state";
+
+describe("justSavedOnRunStart", () => {
+  it("resets the saved confirmation when a new run begins", () => {
+    // Regardless of the previous flag, a new retrieval or answer run
+    // invalidates the save confirmation.
+    expect(justSavedOnRunStart()).toBe(false);
+  });
+});
+
+describe("justSavedOnSaveComplete", () => {
+  it("sets the saved confirmation to true after a successful POST", () => {
+    expect(justSavedOnSaveComplete(true)).toBe(true);
+  });
+
+  it("leaves the saved confirmation false after a failed POST", () => {
+    expect(justSavedOnSaveComplete(false)).toBe(false);
+  });
+});
+
+describe("save-button state machine", () => {
+  it("models the full user flow: save → new run → save again", () => {
+    // Starting point: user has run evaluations, button is enabled, not saved.
+    let justSaved = false;
+
+    // User clicks Save, POST succeeds.
+    justSaved = justSavedOnSaveComplete(true);
+    expect(justSaved).toBe(true); // button now shows "Report Saved", disabled
+
+    // User kicks off a new retrieval run.
+    justSaved = justSavedOnRunStart();
+    expect(justSaved).toBe(false); // button returns to "Save report"
+
+    // Run finishes, user clicks Save again, POST succeeds.
+    justSaved = justSavedOnSaveComplete(true);
+    expect(justSaved).toBe(true);
+
+    // User kicks off an answer run this time — same reset.
+    justSaved = justSavedOnRunStart();
+    expect(justSaved).toBe(false);
+  });
+
+  it("does not lock the button after a failed save", () => {
+    let justSaved = false;
+    justSaved = justSavedOnSaveComplete(false); // network error / 500
+    expect(justSaved).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #98.

## Summary

- `SaveReportButton` gets a new `saved` prop; when true, the label is "Report Saved" and the button is disabled.
- `EvaluationsPage` tracks `justSaved` — set true after a successful save, reset to false whenever a new retrieval or answer run starts; failed save never locks the button.
- New `save-report-state.ts` exposes pure helpers (`justSavedOnRunStart`, `justSavedOnSaveComplete`) so the state transitions are unit-testable; covered in `tests/unit/save-report-state.test.ts` (5 new tests, 52/52 total pass).
- `showSaveButton = !viewingSaved` gate from #75 is unchanged — saved-report views still hide the button entirely.

## Test plan

- [x] `pnpm lint` — 0 errors (1 pre-existing unrelated warning).
- [x] `pnpm test:unit` — 52/52 pass (5 new + 47 existing).
- [ ] Manual: run `pnpm dev`, run a retrieval evaluation, click Save report, verify label flips to "Report Saved" + disabled; start another run, verify label resets to "Save report" and re-enables after the run completes.