### PR TITLE
AGENT: shift trace arrow path upward inside viewBox to fix visual centering (#100)

### DIFF
--- a/app/_components/trace-section.tsx
+++ b/app/_components/trace-section.tsx
@@ -169,18 +169,24 @@ function TraceNode({
   );
 }
 
+// Visual-center offset: the arrow glyph's ink is geometrically centerable in
+// its 10×10 viewBox, but the arrowhead (dense stroke convergence in the lower
+// half) carries more visual weight than the thin upper shaft. If we center the
+// path geometrically (top/bottom padding 1.25u each), the glyph's visual
+// center of mass sits BELOW y=5 and the arrow reads as floating high relative
+// to the flanking lines. To compensate, we shift the path upward inside the
+// viewBox — shaft y=0.5→8.0, arrowhead apex at y=4.5 — so the top padding is
+// small (0.5u) and the bottom padding is larger (2.0u). The extra whitespace
+// below the arrowhead balances its visual heft, placing the perceived center
+// at ~y=5 between the h-3 flanking lines.
 function TraceConnector(): React.JSX.Element {
-  // Arrow glyph is 7.5 units tall (shaft y=1.25→8.75) inside a 10×10 viewBox,
-  // giving 1.25u of padding on top and bottom so the glyph is centered in its
-  // SVG box. With equal h-3 flanking lines and matching gap-0.5 gaps, the
-  // overall column is symmetric around the arrow glyph.
   return (
     <div className="flex py-1 pl-[33px]">
       <div className="flex flex-col items-center gap-0.5">
         <div className="h-3 w-px bg-[#9cc9a9]/60" />
         <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
           <path
-            d="M5 1.25V8.75M5 8.75L1.5 5.25M5 8.75L8.5 5.25"
+            d="M5 0.5V8M5 8L1.5 4.5M5 8L8.5 4.5"
             stroke="#6ea580"
             strokeWidth="1.2"
             strokeLinecap="round"


### PR DESCRIPTION
Closes #100. Follow-up to #67 / PR #73 — geometric centering left the arrow reading visually high because the arrowhead's dense stroke convergence carries more visual weight than the thin upper shaft.

## Summary

- Shift the arrow path inside the 10×10 viewBox: shaft `y=0.5→8`, arrowhead apex `y=4.5`. Top padding 0.5u, bottom padding 2.0u — the larger bottom gap compensates for the arrowhead's heavier visual weight.
- Flanking `h-3` line heights, `pl-[33px]` horizontal alignment, color, stroke-width, and linecap all unchanged.
- Add a multi-line comment above `TraceConnector` documenting the visual-center offset and why geometric centering fails.

## Test plan

- [x] `pnpm lint` — 0 errors (1 pre-existing unrelated warning).
- [ ] Manual: run `pnpm dev`, ask a question, expand the trace, verify the arrows between Query/Retrieve/Generate read as visually centered between their flanking lines.