### PR TITLE
Fonts: Inter for body, Sumana for logo/headings (retire Geist + Instrument Serif)

### DIFF
--- a/app/_components/citations-panel.tsx
+++ b/app/_components/citations-panel.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 import type { QueryResponse } from "../../shared/types";
 import { CitationCard } from "./citation-card";
 import {
-  SERIF,
+  LOGO_FONT,
   citationMarkerNumber,
   findRetrievalForCitation,
 } from "./shared";
@@ -35,7 +35,7 @@ export function CitationsPanel({
           <div className="flex items-baseline gap-2">
             <span
               className="text-[20px] tracking-tight text-[#1f2a23]"
-              style={SERIF}
+              style={LOGO_FONT}
             >
               Citations
             </span>

--- a/app/_components/confidence-badge.tsx
+++ b/app/_components/confidence-badge.tsx
@@ -1,4 +1,4 @@
-import { SERIF, CONFIDENCE_COLORS, type ConfidenceTier } from "./shared";
+import { LOGO_FONT, CONFIDENCE_COLORS, type ConfidenceTier } from "./shared";
 
 const CONFIDENCE_TOOLTIP =
   "Based on the semantic similarity score of the best-matching source retrieved for your question. High = score ≥ 0.65, Medium = score ≥ 0.45, Low = score < 0.45.";
@@ -84,7 +84,7 @@ export function ConfidenceBadge({
           <span className={`text-[9px] ${color.text}`}>·</span>
           <span
             className={`text-[13px] leading-none tracking-tight ${color.text}`}
-            style={SERIF}
+            style={LOGO_FONT}
           >
             {label}
           </span>

--- a/app/_components/evaluation-section.tsx
+++ b/app/_components/evaluation-section.tsx
@@ -1,12 +1,12 @@
 import { Card } from "./card";
 import { RunEvaluationButton } from "./run-evaluation-button";
-import { SERIF } from "./shared";
+import { LOGO_FONT } from "./shared";
 
 /**
  * Generic /evaluations section wrapper: title, description, run-button, and
  * a slot for the pre-run hint or the rendered results. Matches the two-card
  * stacked layout from the Gradio prototype but styled with the app theme
- * (muted greens/creams, Card, SERIF title).
+ * (muted greens/creams, Card, LOGO_FONT title).
  *
  * When `runDisabled` is set (e.g. while viewing a saved report), the run
  * button is rendered in a disabled state with a tooltip and the click
@@ -42,7 +42,7 @@ export function EvaluationSection({
           <div>
             <h2
               className="text-[20px] tracking-tight text-[#1f2a23]"
-              style={SERIF}
+              style={LOGO_FONT}
             >
               {title}
             </h2>

--- a/app/_components/history-chunk.tsx
+++ b/app/_components/history-chunk.tsx
@@ -1,5 +1,5 @@
 import { Card } from "./card";
-import { SERIF, confidenceTier } from "./shared";
+import { LOGO_FONT, confidenceTier } from "./shared";
 import { AnswerCard } from "./answer-card";
 import type { HistoryEntry } from "./history-store";
 
@@ -18,7 +18,7 @@ export function HistoryChunk({
         </div>
         <p
           className="mt-3 text-[18px] leading-[1.5] text-[#1f2a23]"
-          style={SERIF}
+          style={LOGO_FONT}
         >
           {entry.query}
         </p>

--- a/app/_components/library-card.tsx
+++ b/app/_components/library-card.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Card } from "./card";
-import { SERIF, authorityStyle, type Authority } from "./shared";
+import { LOGO_FONT, authorityStyle, type Authority } from "./shared";
 import type { CorpusDoc } from "../_lib/corpus";
 
 const SNIPPET_MAX_CHARS = 180;
@@ -44,7 +44,7 @@ export function LibraryCard({ doc }: { doc: CorpusDoc }): React.JSX.Element {
 
         <h2
           className="mt-2 line-clamp-2 text-[16px] leading-snug tracking-tight text-[#1f2a23]"
-          style={SERIF}
+          style={LOGO_FONT}
         >
           {doc.title}
         </h2>

--- a/app/_components/markdown.tsx
+++ b/app/_components/markdown.tsx
@@ -1,4 +1,4 @@
-import { SERIF } from "./shared";
+import { LOGO_FONT } from "./shared";
 
 /**
  * Minimal server-side markdown renderer.
@@ -22,7 +22,7 @@ export function Markdown({ source }: { source: string }): React.JSX.Element {
             <h1
               key={i}
               className="mt-2 text-[26px] leading-tight tracking-tight text-[#1f2a23]"
-              style={SERIF}
+              style={LOGO_FONT}
             >
               {block.slice(2)}
             </h1>
@@ -33,7 +33,7 @@ export function Markdown({ source }: { source: string }): React.JSX.Element {
             <h2
               key={i}
               className="mb-2 mt-6 text-[20px] leading-tight tracking-tight text-[#1f2a23]"
-              style={SERIF}
+              style={LOGO_FONT}
             >
               {block.slice(3)}
             </h2>

--- a/app/_components/shared.ts
+++ b/app/_components/shared.ts
@@ -2,7 +2,6 @@ import type { Citation, ChunkMetadata, Retrieval } from "../../shared/types";
 
 // ── visual tokens ─────────────────────────────────────────────────────────
 
-export const SERIF = { fontFamily: "var(--font-serif)" };
 export const LOGO_FONT = { fontFamily: "var(--font-logo)" };
 
 // ── authority styles ──────────────────────────────────────────────────────

--- a/app/_components/trace-section.tsx
+++ b/app/_components/trace-section.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import type { Citation, Retrieval } from "../../shared/types";
 import { Card } from "./card";
 import {
-  SERIF,
+  LOGO_FONT,
   type ConfidenceTier,
   type RunMeta,
   RETRIEVE_THRESHOLD,
@@ -57,7 +57,7 @@ export function TraceSection({
           </span>
           <span
             className="text-[20px] tracking-tight text-[#1f2a23]"
-            style={SERIF}
+            style={LOGO_FONT}
           >
             Trace
           </span>

--- a/app/design-preview/page.tsx
+++ b/app/design-preview/page.tsx
@@ -1,16 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Instrument_Serif } from "next/font/google";
+import { Inter } from "next/font/google";
+import { LOGO_FONT } from "../_components/shared";
 
-const geist = Geist({
+const inter = Inter({
   subsets: ["latin"],
   variable: "--font-sans",
   weight: ["300", "400", "500", "600"],
-});
-const serif = Instrument_Serif({
-  weight: "400",
-  subsets: ["latin"],
-  variable: "--font-serif",
-  style: ["normal", "italic"],
 });
 
 export const metadata: Metadata = {
@@ -164,8 +159,6 @@ const AUTHORITY_STYLES: Record<
   },
 };
 
-const SERIF = { fontFamily: "var(--font-serif)" };
-
 const CARD =
   "rounded-2xl bg-white/80 backdrop-blur-md ring-1 ring-[#2d4a35]/[0.08] shadow-[0_2px_8px_-2px_rgba(45,74,53,0.06),0_12px_32px_-8px_rgba(45,74,53,0.08)]";
 
@@ -174,7 +167,7 @@ const CARD =
 export default function DesignPreview(): React.JSX.Element {
   return (
     <div
-      className={`${geist.variable} ${serif.variable} relative min-h-screen overflow-x-hidden text-[#2a2f2c]`}
+      className={`${inter.variable} relative min-h-screen overflow-x-hidden text-[#2a2f2c]`}
       style={{ fontFamily: "var(--font-sans)" }}
     >
       <BackgroundLayers />
@@ -249,7 +242,7 @@ function Header(): React.JSX.Element {
         <div className="flex flex-col leading-none">
           <span
             className="text-[19px] tracking-tight text-[#1f2a23]"
-            style={SERIF}
+            style={LOGO_FONT}
           >
             Compliance Copilot
           </span>
@@ -397,7 +390,7 @@ function ConfidenceBadge(): React.JSX.Element {
         </span>
         <span
           className="mt-1 text-[18px] leading-none tracking-tight text-[#6b2d0e]"
-          style={SERIF}
+          style={LOGO_FONT}
         >
           High
         </span>
@@ -434,7 +427,7 @@ function TraceSection(): React.JSX.Element {
         <div className="flex items-center gap-4">
           <span
             className="text-[20px] tracking-tight text-[#1f2a23]"
-            style={SERIF}
+            style={LOGO_FONT}
           >
             Trace
           </span>
@@ -722,7 +715,7 @@ function CitationsPanel(): React.JSX.Element {
         <div className="flex items-baseline gap-2">
           <span
             className="text-[20px] tracking-tight text-[#1f2a23]"
-            style={SERIF}
+            style={LOGO_FONT}
           >
             Citations
           </span>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,13 @@
 import type { Metadata } from "next";
-import { Geist, Instrument_Serif, Sumana } from "next/font/google";
+import { Inter, Sumana } from "next/font/google";
 import "./globals.css";
 import { BackgroundLayers } from "./_components/background-layers";
 import { Sidebar } from "./_components/sidebar";
 
-const geist = Geist({
+const inter = Inter({
   subsets: ["latin"],
   variable: "--font-sans",
   weight: ["300", "400", "500", "600"],
-});
-
-const serif = Instrument_Serif({
-  weight: "400",
-  subsets: ["latin"],
-  variable: "--font-serif",
-  style: ["normal", "italic"],
 });
 
 const logo = Sumana({
@@ -37,7 +30,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geist.variable} ${serif.variable} ${logo.variable} min-h-screen text-[#2a2f2c] antialiased`}
+        className={`${inter.variable} ${logo.variable} min-h-screen text-[#2a2f2c] antialiased`}
         style={{ fontFamily: "var(--font-sans)" }}
       >
         <div className="relative flex min-h-screen">


### PR DESCRIPTION
Closes #107.

- Swaps Geist → Inter for `--font-sans`; Inter is now the default body face.
- Drops the Instrument Serif loader and `--font-serif` variable.
- Converts all 12 remaining `style={SERIF}` sites to `style={LOGO_FONT}` (Sumana) — card titles, section headers, markdown h1/h2, trace/citations labels, confidence tier, history query, and the design-preview mirrors.
- Removes the now-unused `SERIF` export from `shared.ts` and the design-preview's local `SERIF` constant.

Post-change grep: `SERIF\b`, `Instrument_Serif`, `Geist`, and `--font-serif` all return zero matches in `app/`.