### PR TITLE
Evaluations: restyle Run/Save buttons to match Ask (dark turquoise)

### DIFF
--- a/app/_components/run-evaluation-button.tsx
+++ b/app/_components/run-evaluation-button.tsx
@@ -36,7 +36,7 @@ export function RunEvaluationButton({
         aria-busy={busy}
         aria-label={busy ? progressText : idleLabel}
         title={!busy && disabled ? disabledReason : undefined}
-        className="group relative inline-flex items-center gap-2 overflow-hidden rounded-xl bg-[#2d4a35] px-5 py-2.5 text-[13px] font-medium text-white shadow-[0_2px_8px_-2px_rgba(45,74,53,0.35)] transition-all hover:bg-[#1f3526] hover:shadow-[0_4px_14px_-2px_rgba(45,74,53,0.45)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-[#2d4a35]"
+        className="group relative inline-flex h-10 shrink-0 items-center gap-2 overflow-hidden rounded-xl bg-[#0e6d6b] px-5 text-[13px] font-medium text-white shadow-[0_2px_8px_-2px_rgba(14,109,107,0.35)] transition-all hover:bg-[#0a5754] hover:shadow-[0_4px_14px_-2px_rgba(14,109,107,0.45)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-[#0e6d6b]"
       >
         {busy ? <Spinner /> : null}
         <span>{busy ? "Evaluating…" : idleLabel}</span>

--- a/app/_components/save-report-button.tsx
+++ b/app/_components/save-report-button.tsx
@@ -34,7 +34,7 @@ export function SaveReportButton({
           ? "Run at least one evaluation to save a report"
           : undefined
       }
-      className="inline-flex items-center gap-2 rounded-xl border border-[#2d4a35]/30 bg-white/80 px-4 py-1.5 text-[13px] font-medium text-[#2d4a35] shadow-sm transition-colors hover:bg-[#dfeee3]/60 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white/80"
+      className="group relative inline-flex h-10 shrink-0 items-center gap-2 overflow-hidden rounded-xl bg-[#0e6d6b] px-5 text-[13px] font-medium text-white shadow-[0_2px_8px_-2px_rgba(14,109,107,0.35)] transition-all hover:bg-[#0a5754] hover:shadow-[0_4px_14px_-2px_rgba(14,109,107,0.45)] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-[#0e6d6b]"
     >
       {label}
     </button>


### PR DESCRIPTION
Closes #108.

Two-line className swap on `run-evaluation-button.tsx` and `save-report-button.tsx` so both adopt the Ask button palette: `#0e6d6b` base, `#0a5754` hover, matching shadow + height + padding. ReportSelector (`<select>`) is unchanged. Ask button untouched.