### PR TITLE
Answer card: extend peach gradient fade from 70% → 100%

### DIFF
--- a/app/_components/answer-card.tsx
+++ b/app/_components/answer-card.tsx
@@ -47,7 +47,7 @@ export function AnswerCard({
         className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full"
         style={{
           background:
-            "radial-gradient(circle, rgba(253,228,212,0.7) 0%, rgba(253,228,212,0) 70%)",
+            "radial-gradient(circle, rgba(253,228,212,0.7) 0%, rgba(253,228,212,0) 100%)",
         }}
       />
 


### PR DESCRIPTION
Closes #116.

One-line change in `answer-card.tsx`: the decorative radial gradient's terminal stop moves from `70%` to `100%` so the peach color tapers smoothly to transparent at the edge instead of cutting off early.