### PR TITLE
Trace header: pin label + metadata on one horizontal row

### DIFF
--- a/app/_components/trace-section.tsx
+++ b/app/_components/trace-section.tsx
@@ -31,7 +31,7 @@ export function TraceSection({
 
   return (
     <div className="pt-2" data-testid="trace">
-      <div className="mb-1 flex flex-wrap items-center gap-4">
+      <div className="mb-1 flex items-center justify-between gap-4">
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
@@ -62,7 +62,7 @@ export function TraceSection({
             Trace
           </span>
         </button>
-        <div className="flex flex-wrap items-center gap-4 rounded-full bg-white/60 px-3.5 py-1.5 text-[11px] text-[#435048] ring-1 ring-[#2d4a35]/[0.08] backdrop-blur-md">
+        <div className="flex items-center gap-4 rounded-full bg-white/60 px-3.5 py-1.5 text-[11px] text-[#435048] ring-1 ring-[#2d4a35]/[0.08] backdrop-blur-md">
           <TraceMeta label="Run" value={`#${runMeta.run}`} mono />
           <span className="h-2.5 w-px bg-[#2d4a35]/15" />
           <TraceMeta label="When" value={runMeta.when} />


### PR DESCRIPTION
Closes #117.

Drops `flex-wrap` from both the outer trace-header row and the inner metadata pill, and adds `justify-between` so the chevron+Trace label pins left and the run/when/duration pill pins right on a single row. Everything else about the header (chevron, rotation, aria attributes, expanded body) is untouched.