### PR TITLE
Cards: promote Question/Answer labels to Sumana section headings

### DIFF
--- a/app/_components/answer-card.tsx
+++ b/app/_components/answer-card.tsx
@@ -3,6 +3,7 @@ import type { Citation, Retrieval } from "../../shared/types";
 import { Card } from "./card";
 import {
   type ConfidenceTier,
+  LOGO_FONT,
   parseAnswerParts,
   findRetrievalForCitation,
   citationMarkerNumber,
@@ -52,9 +53,12 @@ export function AnswerCard({
       />
 
       <div className="flex items-start justify-between gap-4">
-        <label className="text-[11px] uppercase tracking-[0.18em] text-[#6b7a70]">
+        <h2
+          className="text-[20px] tracking-tight text-[#1f2a23]"
+          style={LOGO_FONT}
+        >
           Answer
-        </label>
+        </h2>
         <ConfidenceBadge tier={tier} />
       </div>
 

--- a/app/_components/question-card.tsx
+++ b/app/_components/question-card.tsx
@@ -1,3 +1,5 @@
+import { LOGO_FONT } from "./shared";
+
 export function QuestionCard({
   query,
   setQuery,
@@ -19,7 +21,8 @@ export function QuestionCard({
       <div className="flex items-center justify-between">
         <label
           htmlFor="question-input"
-          className="text-[11px] uppercase tracking-[0.18em] text-[#6b7a70]"
+          className="text-[20px] tracking-tight text-[#1f2a23]"
+          style={LOGO_FONT}
         >
           Question
         </label>


### PR DESCRIPTION
Closes #118.

Both `QuestionCard` and `AnswerCard` now render their section title at 20px Sumana with dark text, matching the Trace header treatment. `Question` stays a `<label htmlFor="question-input">` to keep its form-label association; `Answer` becomes an `<h2>` (it had no `htmlFor`). The "Press ⌘↵ to submit" hint and the Answer row's ConfidenceBadge are untouched.