### PR TITLE
AGENT: arrows adjacent to text in sample-questions, lighten text color (#114)

### DIFF
--- a/app/_components/sample-questions.tsx
+++ b/app/_components/sample-questions.tsx
@@ -55,7 +55,7 @@ export function SampleQuestions({
 
   return (
     <div
-      className="flex items-center gap-2"
+      className="flex flex-wrap items-center justify-center gap-2"
       data-testid="sample-questions"
     >
       <button
@@ -79,9 +79,9 @@ export function SampleQuestions({
         type="button"
         onClick={() => onSelect(current.question)}
         aria-label={`Use sample question for ${current.topic}`}
-        className="group flex min-w-0 flex-1 items-center justify-center text-center transition-colors hover:text-[#2d4a35] focus:outline-none focus:ring-2 focus:ring-[#9cc9a9]/40"
+        className="group flex min-w-0 items-center justify-center text-center transition-colors hover:text-[#2d4a35] focus:outline-none focus:ring-2 focus:ring-[#9cc9a9]/40"
       >
-        <span className="min-w-0 flex-1 text-center text-[13px] leading-relaxed text-[#1f2a23]">
+        <span className="min-w-0 max-w-[480px] text-center text-[13px] leading-relaxed text-[#6b7a70]">
           {current.question}
         </span>
       </button>


### PR DESCRIPTION
Closes #114.

## Summary

- Drop `flex-1` from the sample-question text button and its inner span so the arrows hug the text; container uses `justify-center` (+ `flex-wrap` for narrow viewports) to center the whole group.
- Cap text width with `max-w-[480px]` so long questions wrap rather than overflow.
- Lighten the question text from `text-[#1f2a23]` to `text-[#6b7a70]` (same token as the arrow icons in this file). Hover darken-to-`#2d4a35` kept as-is.

## Test plan

- [x] `pnpm lint` — 0 errors (1 pre-existing unrelated warning).
- [ ] Manual: run `pnpm dev`, scroll through the sample-question slider, confirm arrows sit next to the text (not at the container edges), the text reads as muted helper color, hover darkens it, and long questions wrap instead of overflowing.