### PR TITLE
AGENT: group question + sample-questions and center dashboard content (#124)

### DIFF
--- a/app/Pages/DashboardPage.tsx
+++ b/app/Pages/DashboardPage.tsx
@@ -99,23 +99,25 @@ export function DashboardPage(): React.JSX.Element {
   return (
     <main className="relative flex min-w-0 flex-1 items-stretch justify-center gap-8 px-8 pb-24 pt-4">
       <FlockLoader active={loading} />
-      <section className="flex w-full min-w-0 max-w-[700px] flex-col justify-around">
-        <QuestionCard
-          query={query}
-          setQuery={setQuery}
-          onSubmit={() => void handleSubmit()}
-          onKeyDown={handleKeyDown}
-          loading={loading}
-          textareaRef={textareaRef}
-        />
+      <section className="flex w-full min-w-0 max-w-[700px] flex-col justify-center">
+        <div className="space-y-2">
+          <QuestionCard
+            query={query}
+            setQuery={setQuery}
+            onSubmit={() => void handleSubmit()}
+            onKeyDown={handleKeyDown}
+            loading={loading}
+            textareaRef={textareaRef}
+          />
 
-        {/* TEMP_SAMPLE_QUESTIONS: Remove when issue #37 affordance is no longer needed. */}
-        <SampleQuestions
-          onSelect={(q) => {
-            setQuery(q);
-            textareaRef.current?.focus();
-          }}
-        />
+          {/* TEMP_SAMPLE_QUESTIONS: Remove when issue #37 affordance is no longer needed. */}
+          <SampleQuestions
+            onSelect={(q) => {
+              setQuery(q);
+              textareaRef.current?.focus();
+            }}
+          />
+        </div>
 
         {error && (
           <Card className="p-5 text-[13px] text-[#8b3a2f]">{error}</Card>


### PR DESCRIPTION
Closes #124.

## Summary

- Wrap `QuestionCard` and `SampleQuestions` in a shared `<div className="space-y-2">` so they read as one cluster rather than two sibling blocks. `TEMP_SAMPLE_QUESTIONS` comment preserved inside the wrapper.
- Change `<section>` vertical flex from `justify-around` to `justify-center` so the cluster sits centered vertically when no result is present.
- Outer `<main>`, `FlockLoader`, and `CitationsPanel` untouched.

## Test plan

- [x] `pnpm lint` — 0 errors (1 pre-existing unrelated warning).
- [ ] Manual: run `pnpm dev`, verify the question + sample-question slider look grouped; with no question asked, the cluster is centered vertically; after a question, AnswerCard + TraceSection stack below.