### PR TITLE
AGENT: expand answer-card corner glow into full-card peach wash (#125)

### DIFF
--- a/app/_components/answer-card.tsx
+++ b/app/_components/answer-card.tsx
@@ -45,10 +45,10 @@ export function AnswerCard({
     >
       <div
         aria-hidden
-        className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full"
+        className="pointer-events-none absolute inset-0"
         style={{
           background:
-            "radial-gradient(circle, rgba(253,228,212,0.7) 0%, rgba(253,228,212,0) 100%)",
+            "radial-gradient(circle at 90% 10%, rgba(253,228,212,0.45) 0%, rgba(253,228,212,0) 75%)",
         }}
       />
 


### PR DESCRIPTION
Closes #125.

## Summary

- Change the decorative gradient layer from a 128×128 top-right corner glow to a full-bleed `absolute inset-0` div.
- Gradient: `radial-gradient(circle at 90% 10%, rgba(253,228,212,0.45) 0%, rgba(253,228,212,0) 75%)` — off-screen radial anchored top-right, wide falloff, alpha 0.45 for legibility.
- `pointer-events-none` and `aria-hidden` preserved. `Card`'s `overflow-hidden` still clips to rounded corners.

## Test plan

- [x] `pnpm lint` — 0 errors.
- [ ] Manual: run `pnpm dev`, ask a question, verify the answer card has a warm peach wash across the whole card; body text, citation chips, and confidence badge stay legible.