### PR TITLE
AGENT: horizontally center TraceConnector arrows within trace column (#126)

### DIFF
--- a/app/_components/trace-section.tsx
+++ b/app/_components/trace-section.tsx
@@ -195,7 +195,7 @@ function TraceNode({
 // at ~y=5 between the h-3 flanking lines.
 function TraceConnector(): React.JSX.Element {
   return (
-    <div className="flex py-1 pl-[33px]">
+    <div className="flex justify-center py-1">
       <div className="flex flex-col items-center gap-0.5">
         <div className="h-3 w-px bg-[#9cc9a9]/60" />
         <svg width="10" height="10" viewBox="0 0 10 10" fill="none">


### PR DESCRIPTION
Closes #126.

## Summary

- Replace `pl-[33px]` left-inset with `justify-center` on the `TraceConnector` wrapper so the arrow column auto-centers within the trace column's full width, placing the arrows on the horizontal midline of the cards above/below rather than at the node-dot column.
- SVG path coordinates, the `h-3` flanking lines, the visual-center comment from PR #104, and the #99 overflow padding wrapper are all untouched.

## Test plan

- [x] `pnpm lint` — 0 errors.
- [ ] Manual: run `pnpm dev`, ask a question, expand the trace, verify the arrow between each pair of trace nodes sits on the horizontal midline of the cards, not at the node-dot column.