### PR TITLE
AGENT: lighten answer-card peach gradient toward white (#130)

### DIFF
--- a/app/_components/answer-card.tsx
+++ b/app/_components/answer-card.tsx
@@ -48,7 +48,7 @@ export function AnswerCard({
         className="pointer-events-none absolute inset-0"
         style={{
           background:
-            "radial-gradient(circle at 90% 10%, rgba(253,228,212,0.45) 0%, rgba(253,228,212,0) 75%)",
+            "radial-gradient(circle at 90% 10%, rgba(255,243,236,0.35) 0%, rgba(255,243,236,0) 75%)",
         }}
       />
 


### PR DESCRIPTION
Closes #130.

## Summary

- Shift the decorative gradient color from `rgba(253,228,212,*)` to `rgba(255,243,236,*)` — closer to white with a faint peach tint.
- Drop peak alpha from `0.45` to `0.35` for an even lighter wash.
- Gradient shape (`radial-gradient(circle at 90% 10%, ... 0%, ... 75%)`) and all other attributes preserved.

## Test plan

- [x] `pnpm lint` — 0 errors.
- [ ] Manual: run `pnpm dev`, ask a question, verify the answer card has a barely-there warm wash rather than a pink tint.