### PR TITLE
AGENT: fade Q/A during loading, top-align when answer shows, align headings (#131)

### DIFF
--- a/app/Pages/DashboardPage.tsx
+++ b/app/Pages/DashboardPage.tsx
@@ -97,9 +97,13 @@ export function DashboardPage(): React.JSX.Element {
   );
 
   return (
-    <main className="relative flex min-w-0 flex-1 items-stretch justify-center gap-8 px-8 pb-24 pt-4">
+    <main className="relative flex min-w-0 flex-1 items-stretch justify-center gap-8 px-8 pb-24 pt-6">
       <FlockLoader active={loading} />
-      <section className="flex w-full min-w-0 max-w-[700px] flex-col justify-center">
+      <section
+        className={`flex w-full min-w-0 max-w-[700px] flex-col transition-opacity duration-200 ${
+          result ? "justify-start" : "justify-center"
+        } ${loading ? "opacity-50" : "opacity-100"}`}
+      >
         <div className="space-y-2">
           <QuestionCard
             query={query}


### PR DESCRIPTION
Closes #131.

## Summary

- `<section>` gets a conditional opacity toggle: `opacity-50` while `loading` is true, `opacity-100` otherwise, with `transition-opacity duration-200` for a smooth fade.
- `<section>` uses `justify-start` when `result` is truthy (content anchors to top) and `justify-center` when null (preserves #124's empty-state centering).
- `<main>` top padding `pt-4` → `pt-6` so it matches `CitationsPanel`'s `sticky top-6`, aligning the "Question" and "Citations" labels at the same 24px Y offset.
- CitationsPanel, QuestionCard, AnswerCard, TraceSection, FlockLoader, SampleQuestions — all untouched.

## Test plan

- [x] `pnpm lint` — 0 errors.
- [ ] Manual: run `pnpm dev`, submit a question, confirm the Q/A area fades to 50% during loading and returns to 100% when the answer lands; confirm Question/Citations labels line up horizontally; confirm the empty state is still vertically centered.