### PR TITLE
AGENT: narrow citations panel to 320px and align heading with Question (#135)

### DIFF
--- a/app/_components/citations-panel.tsx
+++ b/app/_components/citations-panel.tsx
@@ -26,11 +26,11 @@ export function CitationsPanel({
     <aside
       aria-hidden={!open}
       className={`shrink-0 overflow-hidden transition-[width,opacity] duration-300 ease-out ${
-        open ? "w-[360px] opacity-100" : "w-0 opacity-0"
+        open ? "w-[320px] opacity-100" : "w-0 opacity-0"
       }`}
       data-testid="citations-panel"
     >
-      <div className="sticky top-6 w-[360px] space-y-4 pr-1">
+      <div className="w-[320px] space-y-4 pr-1">
         <div className="flex items-end justify-between px-1">
           <div className="flex items-baseline gap-2">
             <span


### PR DESCRIPTION
Closes #135.

## Summary

- Panel width `w-[360px]` → `w-[320px]` on both the `<aside>` open state and the inner wrapper.
- Remove `sticky top-6` from the inner wrapper — the aside stretches to main's height so there's no independent scroll context; the offset was creating a visual gap rather than sticky behavior. Without it the "Citations" heading sits at the aside's top (24px via main's `pt-6`), aligning with the "Question" label.

## Test plan

- [x] `pnpm lint` — 0 errors.
- [ ] Manual: run `pnpm dev`, ask a question, verify the Citations panel is narrower (~320px) and its heading lines up with the Question label in the Q/A column.