### PR TITLE
Add Pushover sendPushover helper and /api/test-pushover diagnostic endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@ PINECONE_API_KEY=
 
 # Pinecone index name — the target index for upsert and query.
 PINECONE_INDEX=
+
+# Pushover credentials — used to push a notification when the daily request cap is hit.
+# Both must be set for notifications to fire; missing values are warned and skipped.
+PUSHOVER_USER=
+PUSHOVER_TOKEN=

--- a/app/api/test-pushover/route.ts
+++ b/app/api/test-pushover/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { sendPushover } from "../../../pipeline/notify-pushover";
+
+export async function GET(): Promise<NextResponse> {
+  const result = await sendPushover(
+    "Compliance Copilot: test",
+    `Test notification at ${new Date().toISOString()}`,
+  );
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { ok: false, error: result.reason },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/pipeline/notify-pushover.ts
+++ b/pipeline/notify-pushover.ts
@@ -1,0 +1,32 @@
+const PUSHOVER_URL = "https://api.pushover.net/1/messages.json";
+
+export async function sendPushover(
+  title: string,
+  message: string,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const user = process.env["PUSHOVER_USER"];
+  const token = process.env["PUSHOVER_TOKEN"];
+
+  if (!user || !token) {
+    const reason = "missing PUSHOVER_USER or PUSHOVER_TOKEN";
+    console.warn(`[pushover] ${reason} — skipping notification`);
+    return { ok: false, reason };
+  }
+
+  const body = new URLSearchParams({ token, user, title, message });
+
+  const res = await fetch(PUSHOVER_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "<no body>");
+    const reason = `Pushover ${res.status}: ${text}`;
+    console.error(`[pushover] ${reason}`);
+    return { ok: false, reason };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
Scaffolding for #138.

## Summary

- `pipeline/notify-pushover.ts` — `sendPushover(title, message)` POSTs to Pushover; warns and returns `{ok: false}` if `PUSHOVER_USER` / `PUSHOVER_TOKEN` are missing.
- `app/api/test-pushover/route.ts` — GET endpoint for manual smoke-testing (visit `/api/test-pushover` to send a test push).
- `.env.example` — document the two new env vars.

## Test plan

- [x] Verified locally: `pnpm dev` + visit `http://localhost:3000/api/test-pushover` → push received.