### PR TITLE
AGENT: add 500/day request cap on /api/query with Pushover notification (#138)

### DIFF
--- a/app/api/query/route.ts
+++ b/app/api/query/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { graph } from "../../../pipeline/graph";
 import type { QueryResponse } from "../../../shared/types";
 import { bumpQuery, logMemory, snapshot } from "../../../pipeline/instrument";
+import { record } from "../../../pipeline/daily-cap";
+import { sendPushover } from "../../../pipeline/notify-pushover";
 
 const REQUEST_TIMEOUT_MS = 45_000;
 
@@ -19,6 +21,21 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: "Missing or invalid query" },
       { status: 400 },
     );
+  }
+
+  const cap = record();
+  if (!cap.allowed) {
+    return NextResponse.json(
+      { error: "Daily request limit reached. Please try again tomorrow." },
+      { status: 429 },
+    );
+  }
+  if (cap.justHitCap) {
+    // Fire and forget but log errors; never throw to the user.
+    void sendPushover(
+      "Compliance Copilot: daily cap hit",
+      `500/day request cap reached at ${new Date().toISOString()}. Limit resets at next UTC midnight.`,
+    ).catch((err) => console.error("[daily-cap] pushover failed", err));
   }
 
   const n = bumpQuery();

--- a/pipeline/daily-cap.ts
+++ b/pipeline/daily-cap.ts
@@ -1,0 +1,67 @@
+/**
+ * Module-level daily request counter for `/api/query` (issue #138).
+ *
+ * Tracks how many requests have been served in the current UTC day and
+ * exposes a single `record()` function that callers invoke once per
+ * incoming request. The counter automatically resets at UTC midnight,
+ * and the `justHitCap` flag fires exactly once per day (on the request
+ * that brings the count up to `DAILY_LIMIT`) so the route handler can
+ * trigger a single Pushover notification per day.
+ *
+ * State is intentionally module-level (in-process) — a single Next.js
+ * server instance is sufficient for the current deployment. If we ever
+ * scale horizontally we'll need to move this to a shared store.
+ */
+export type RecordResult = {
+  allowed: boolean;
+  count: number;
+  justHitCap: boolean;
+};
+
+export const DAILY_LIMIT = 500;
+
+type State = {
+  windowStart: Date | null;
+  count: number;
+  capNotified: boolean;
+};
+
+const state: State = {
+  windowStart: null,
+  count: 0,
+  capNotified: false,
+};
+
+function utcDateString(d: Date): string {
+  // YYYY-MM-DD in UTC, used to detect day-boundary rollovers.
+  return d.toISOString().slice(0, 10);
+}
+
+export function record(now: Date = new Date()): RecordResult {
+  const today = utcDateString(now);
+  if (
+    state.windowStart === null ||
+    utcDateString(state.windowStart) !== today
+  ) {
+    state.windowStart = now;
+    state.count = 0;
+    state.capNotified = false;
+  }
+
+  if (state.count >= DAILY_LIMIT) {
+    return { allowed: false, count: state.count, justHitCap: false };
+  }
+
+  state.count += 1;
+  if (state.count === DAILY_LIMIT && !state.capNotified) {
+    state.capNotified = true;
+    return { allowed: true, count: state.count, justHitCap: true };
+  }
+  return { allowed: true, count: state.count, justHitCap: false };
+}
+
+export function _resetForTests(): void {
+  state.windowStart = null;
+  state.count = 0;
+  state.capNotified = false;
+}

--- a/tests/unit/daily-cap.test.ts
+++ b/tests/unit/daily-cap.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the daily request counter (`pipeline/daily-cap.ts`,
+ * issue #138).
+ *
+ * Covers the five behaviours called out in the spec:
+ *   - first call increments to 1 and is allowed,
+ *   - the 500th call is allowed and flips `justHitCap` true,
+ *   - the 501st (and 502nd) call is rejected with `justHitCap` false,
+ *   - a UTC day rollover resets the counter and re-arms `justHitCap`,
+ *   - `_resetForTests()` clears module-level state between cases.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  record,
+  DAILY_LIMIT,
+  _resetForTests,
+} from "../../pipeline/daily-cap";
+
+beforeEach(() => {
+  _resetForTests();
+});
+
+describe("daily-cap.record", () => {
+  it("starts at 0 and the first call returns count: 1, allowed", () => {
+    const result = record();
+    expect(result).toEqual({ allowed: true, count: 1, justHitCap: false });
+  });
+
+  it("flips justHitCap true exactly on the 500th call", () => {
+    let result = { allowed: true, count: 0, justHitCap: false };
+    for (let i = 0; i < DAILY_LIMIT; i++) {
+      result = record();
+    }
+    expect(result).toEqual({
+      allowed: true,
+      count: DAILY_LIMIT,
+      justHitCap: true,
+    });
+  });
+
+  it("rejects the 501st call without incrementing or re-firing justHitCap", () => {
+    for (let i = 0; i < DAILY_LIMIT; i++) {
+      record();
+    }
+    const overCap = record();
+    expect(overCap).toEqual({
+      allowed: false,
+      count: DAILY_LIMIT,
+      justHitCap: false,
+    });
+  });
+
+  it("does not flip justHitCap true again on subsequent over-cap calls", () => {
+    for (let i = 0; i < DAILY_LIMIT; i++) {
+      record();
+    }
+    const r501 = record();
+    const r502 = record();
+    expect(r501).toEqual({
+      allowed: false,
+      count: DAILY_LIMIT,
+      justHitCap: false,
+    });
+    expect(r502).toEqual({
+      allowed: false,
+      count: DAILY_LIMIT,
+      justHitCap: false,
+    });
+  });
+
+  it("resets count and re-arms justHitCap on UTC day rollover", () => {
+    // Two timestamps: same wall-clock time of day, but one UTC day apart.
+    // Using 2026-01-01 vs 2026-01-02 keeps us safely away from any
+    // local-timezone edge cases — the module compares UTC date strings.
+    const day1 = new Date("2026-01-01T12:00:00.000Z");
+    const day2 = new Date("2026-01-02T12:00:00.000Z");
+
+    // Fill day 1 right up to the cap so capNotified is set.
+    for (let i = 0; i < DAILY_LIMIT; i++) {
+      const r = record(day1);
+      if (i === DAILY_LIMIT - 1) {
+        expect(r.justHitCap).toBe(true);
+      }
+    }
+    // 501st on day 1 is rejected.
+    expect(record(day1)).toEqual({
+      allowed: false,
+      count: DAILY_LIMIT,
+      justHitCap: false,
+    });
+
+    // First call on day 2 resets the window: count returns to 1 and the
+    // cap-hit flag is re-armed (so a new day-2 cap-hit will fire again).
+    expect(record(day2)).toEqual({
+      allowed: true,
+      count: 1,
+      justHitCap: false,
+    });
+
+    // Confirm the re-arming by driving day 2 up to the cap as well.
+    let last = { allowed: true, count: 1, justHitCap: false };
+    for (let i = 1; i < DAILY_LIMIT; i++) {
+      last = record(day2);
+    }
+    expect(last).toEqual({
+      allowed: true,
+      count: DAILY_LIMIT,
+      justHitCap: true,
+    });
+  });
+});


### PR DESCRIPTION
Closes #138.

## Summary

- **`pipeline/daily-cap.ts`** — module-level UTC-day counter exposing `record()`, `DAILY_LIMIT = 500`, and `_resetForTests()`. The 500th call is allowed and flips `justHitCap: true` exactly once per day; the 501st onward returns `allowed: false` without incrementing. Counter resets at the next UTC midnight and re-arms `justHitCap`.
- **`app/api/query/route.ts`** — gate at the top of POST: returns `429 { error: "Daily request limit reached. Please try again tomorrow." }` when over cap; fires `sendPushover` (fire-and-forget with `void` + `.catch`) when the cap is just hit. Cap gate runs BEFORE `bumpQuery()` so rejected requests don't pollute query metrics.
- **`tests/unit/daily-cap.test.ts`** — 5 vitest cases covering the spec.

## Test plan

- [x] `pnpm lint` — clean on the new files (pre-existing noise in `scripts/verify-eval.ts` and `.claude/worktrees/*` ignored per spec).
- [x] `pnpm test:unit` — passes including the 5 new cases.
- [ ] Manual: deploy to Railway, hit `/api/test-pushover` once to confirm Pushover wiring; the daily cap will fire its own push naturally if traffic ever reaches 500.