### PR TITLE
AGENT: open citations panel when a citation chip is clicked (#141)

### DIFF
--- a/app/Pages/DashboardPage.tsx
+++ b/app/Pages/DashboardPage.tsx
@@ -89,6 +89,7 @@ export function DashboardPage(): React.JSX.Element {
   function handleCitationClick(n: number) {
     const chunkId = chunkIdForMarker(n, result?.citations ?? []);
     if (!chunkId) return;
+    setPanelOpen(true);
     setHighlightedChunkId(chunkId);
     setPulseKey((k) => k + 1);
   }


### PR DESCRIPTION
Closes #141.

## Summary

- `handleCitationClick` in `DashboardPage.tsx` now calls `setPanelOpen(true)` after the early-return on missing chunkId.
- Citation clicks always reveal the citations panel even if the user closed it.
- Highlight + pulse animation behavior unchanged.

## Test plan

- [x] `pnpm lint` — 0 errors.
- [ ] Manual: ask a question, close the citations panel via X, click a `[1]` chip in the answer — panel should re-open and the targeted card should pulse.