### PR TITLE
AGENT: default /evaluations to latest saved report; remove 'Current' option (#142)

### DIFF
--- a/app/Pages/EvaluationsPage.tsx
+++ b/app/Pages/EvaluationsPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AnswerEvaluation } from "../_components/answer-evaluation";
 import { ReportSelector } from "../_components/report-selector";
 import { RetrievalEvaluation } from "../_components/retrieval-evaluation";
@@ -26,13 +26,18 @@ import {
  *   - the "live session" state for the two evaluation sections (running
  *     flags, progress counters, summaries, errors),
  *   - the list of saved reports and which one is currently selected
- *     (`""` = live session, any id = a saved report).
+ *     (`""` = no saved report selected — either no saved reports exist
+ *     yet, or the user just kicked off a live run, any id = a saved
+ *     report).
+ *
+ * On mount, after the saved-report list resolves, we auto-select the
+ * latest saved report so the page renders historical data by default.
+ * When the user clicks Run, `selectedId` flips to `""` so the live
+ * progress + summary takes over. After a successful save, `selectedId`
+ * flips to the new report's id so the dropdown highlights it.
  *
  * When a saved report is selected, the two sections render the persisted
  * summaries and their `Run evaluation` buttons are disabled with a tooltip.
- * Selecting `Current` restores the live session state — we never replace
- * the live state in place, so the user can always toggle back and see
- * whatever they ran this session.
  */
 export function EvaluationsPage(): React.JSX.Element {
   // ── live session state ────────────────────────────────────────────────
@@ -59,7 +64,10 @@ export function EvaluationsPage(): React.JSX.Element {
   const [savedReports, setSavedReports] = useState<readonly SavedReportMeta[]>(
     [],
   );
-  const [selectedId, setSelectedId] = useState<string>(""); // "" = Current
+  // "" = no saved report selected (either none exist yet, or the user is
+  // mid-run / just-ran). On mount, this flips to the latest saved report's
+  // id once the list fetch resolves.
+  const [selectedId, setSelectedId] = useState<string>("");
   const [loadedReport, setLoadedReport] = useState<SavedReport | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -71,7 +79,23 @@ export function EvaluationsPage(): React.JSX.Element {
   // run (which produces a new summary) re-enables the button.
   const [justSaved, setJustSaved] = useState(false);
 
-  // Fetch the saved-report list on mount so the dropdown is populated.
+  // Refs mirroring the live-session state. The mount effect uses these to
+  // decide, at the moment the saved-report list resolves, whether the user
+  // has already kicked off a live run — if so, we must NOT yank `selectedId`
+  // out from under them by auto-selecting the latest saved report.
+  const retrievalSummaryRef = useRef(retrievalSummary);
+  const answerSummaryRef = useRef(answerSummary);
+  const retrievalRunningRef = useRef(retrievalRunning);
+  const answerRunningRef = useRef(answerRunning);
+  retrievalSummaryRef.current = retrievalSummary;
+  answerSummaryRef.current = answerSummary;
+  retrievalRunningRef.current = retrievalRunning;
+  answerRunningRef.current = answerRunning;
+
+  // Fetch the saved-report list on mount so the dropdown is populated, and
+  // auto-select the latest entry so the page renders historical data by
+  // default. If the user has somehow kicked off a live run before the list
+  // resolves, leave `selectedId` alone so the live state stays visible.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -79,7 +103,17 @@ export function EvaluationsPage(): React.JSX.Element {
         const res = await fetch("/api/evaluations/reports");
         if (!res.ok) return;
         const body = (await res.json()) as { reports: SavedReportMeta[] };
-        if (!cancelled) setSavedReports(body.reports ?? []);
+        if (cancelled) return;
+        const reports = body.reports ?? [];
+        setSavedReports(reports);
+        const noLiveRun =
+          retrievalSummaryRef.current === null &&
+          answerSummaryRef.current === null &&
+          !retrievalRunningRef.current &&
+          !answerRunningRef.current;
+        if (reports.length > 0 && noLiveRun) {
+          setSelectedId(reports[0].id);
+        }
       } catch {
         // List failure is non-fatal: the user can still run evaluations.
       }
@@ -120,9 +154,12 @@ export function EvaluationsPage(): React.JSX.Element {
     };
   }, [selectedId]);
 
-  // ── run handlers (only fire when viewing `Current`) ───────────────────
+  // ── run handlers (only fire when no saved report is selected) ─────────
   async function handleRunRetrieval() {
     if (retrievalRunning) return;
+    // Switch out of any saved-report view so the live progress + summary
+    // takes over the cards.
+    setSelectedId("");
     setRetrievalRunning(true);
     setRetrievalError(null);
     setRetrievalSummary(null);
@@ -160,6 +197,9 @@ export function EvaluationsPage(): React.JSX.Element {
 
   async function handleRunAnswer() {
     if (answerRunning) return;
+    // Switch out of any saved-report view so the live progress + summary
+    // takes over the cards.
+    setSelectedId("");
     setAnswerRunning(true);
     setAnswerError(null);
     setAnswerSummary(null);
@@ -216,6 +256,9 @@ export function EvaluationsPage(): React.JSX.Element {
       }
       const meta = (await res.json()) as SavedReportMeta;
       setSavedReports((prev) => [meta, ...prev]);
+      // Auto-select the freshly-saved report so the dropdown highlights it
+      // and the cards switch to the persisted view.
+      setSelectedId(meta.id);
       // Success path: flip the button into its "Report Saved" confirmation
       // state. This only runs if the POST returned ok and parsed cleanly.
       setJustSaved(justSavedOnSaveComplete(true));

--- a/app/_components/evaluation-types.ts
+++ b/app/_components/evaluation-types.ts
@@ -82,7 +82,11 @@ export interface SavedReport extends SavedReportMeta {
  * What the `/evaluations` page renders, after reconciling the live session
  * state against any currently-selected saved report.
  *
- *   - `selectedId === ""`  → live session (whatever the user ran).
+ *   - `selectedId === ""`  → no saved report is currently selected; render
+ *                            the live session state (whatever the user ran
+ *                            this session, or empty cards if nothing yet).
+ *                            This is the page's transient state during a
+ *                            live run and the empty-list initial state.
  *   - `selectedId !== ""`  → the saved report's persisted summaries, or
  *                            null where the saved report didn't include
  *                            that section.

--- a/app/_components/report-selector.tsx
+++ b/app/_components/report-selector.tsx
@@ -3,26 +3,29 @@
 import type { SavedReportMeta } from "./evaluation-types";
 
 /**
- * Dropdown for selecting which report to view on `/evaluations`.
+ * Dropdown for selecting which saved report to view on `/evaluations`.
  *
- * - Default option is `Current` (value `""`) — shows whatever the user has
- *   run in this session.
- * - Each entry of `reports` becomes an option labelled by a human-readable
- *   form of its `savedAt` timestamp.
+ * Each entry of `reports` becomes an option labelled by a human-readable
+ * form of its `savedAt` timestamp. When `reports` is empty, a single
+ * disabled placeholder option keeps the control rendered.
  *
  * Selection is uncontrolled from the dropdown's perspective — the parent
- * owns the `value` and reacts to `onChange`.
+ * owns the `value` and reacts to `onChange`. An empty `value` indicates no
+ * saved report is currently selected (e.g. live run in progress); when in
+ * that state with at least one saved report, the native select renders the
+ * first option but the parent's view still reflects live state.
  */
 export function ReportSelector({
   value,
   reports,
   onChange,
 }: {
-  /** Empty string means "Current"; any other value is a saved report id. */
+  /** A saved report id, or empty string when no saved report is selected. */
   value: string;
   reports: readonly SavedReportMeta[];
   onChange: (id: string) => void;
 }): React.JSX.Element {
+  const hasReports = reports.length > 0;
   return (
     <label className="flex items-center gap-2 text-[12px] text-[#6b7a70]">
       <span className="uppercase tracking-[0.14em]">Report</span>
@@ -32,7 +35,11 @@ export function ReportSelector({
         aria-label="Select report"
         className="rounded-lg border border-[#d9ddd9] bg-white/90 px-3 py-1.5 text-[13px] text-[#1f2a23] shadow-sm outline-none transition-shadow focus:ring-2 focus:ring-[#2d4a35]/30"
       >
-        <option value="">Current</option>
+        {!hasReports && (
+          <option value="" disabled>
+            No saved reports yet
+          </option>
+        )}
         {reports.map((r) => (
           <option key={r.id} value={r.id}>
             {formatTimestamp(r.savedAt)}


### PR DESCRIPTION
Closes #142.

## Summary

- On mount, after `savedReports` resolves with ≥1 entry and no live run is in flight, auto-set `selectedId` to the latest report's id so the page renders historical data by default.
- Remove `<option value="">Current</option>` from `ReportSelector`. When the saved-report list is empty, render a disabled `"No saved reports yet"` placeholder so the control stays visible.
- Run handlers (`handleRunRetrieval`, `handleRunAnswer`) now `setSelectedId("")` first so the live progress + summary takes over the cards immediately.
- After a successful save, `setSelectedId(meta.id)` so the dropdown highlights the freshly-saved report.
- `selectEvaluationView` semantics intentionally preserved — existing 7 unit tests pass unchanged.

## Behaviour notes

- After a successful save, the page immediately switches to viewing the new saved report, which hides the SaveReportButton (`showSaveButton = !viewingSaved`). The "Report Saved" confirmation from #98's state machine still runs internally, but is no longer visually surfaced — the user's confirmation is now the dropdown auto-flipping to the new entry.
- During a live run with at least one saved report present, `selectedId === ""` and the native `<select>` visually highlights the first option (since none of its options match `""`); the cards correctly show live state. Acknowledged minor mismatch — avoiding it would require a visible "Live" label which is a non-goal.

## Test plan

- [x] `pnpm lint` — 0 errors.
- [x] `pnpm test:unit` — 57/57 pass (existing `selectEvaluationView` tests unchanged).
- [ ] Manual: save a report on `/evaluations`; reload the page → latest report renders. Click Run → live state shows. Save the new run → dropdown auto-selects the new report.